### PR TITLE
Detail explanations for running tuleap realtime

### DIFF
--- a/languages/en/developer-guide/quick-start/run-tuleap-realtime.rst
+++ b/languages/en/developer-guide/quick-start/run-tuleap-realtime.rst
@@ -22,7 +22,7 @@ Before you start, you need to generate a self signed certificate for Node.js ser
 .. NOTE:: These generated files can be where you want. Just after you will need to specify the path of 'key.pem' and 'cert.pem' files.
 
 .. IMPORTANT:: When you generate the CSR, only the Common Name is important and it has to be the site name to secure.
-    As you are in local you can set the name 'NodeJS' (used after).
+    As this is a dev setup, you can set the name to 'NodeJS' (used after).
 
 Descriptions of commands
 ------------------------
@@ -39,17 +39,21 @@ First connect to Node.js server:
 .. code-block:: bash
 
     $ cd tuleap-realtime
-    $ docker run --rm -v "$PWD/":/nodeapp --entrypoint=bash -ti -p 4443:4443 enalean/node-dev-simple
+    $ docker run -it --rm -v "$PWD/":/nodeapp --entrypoint=bash -p 4443:4443 enalean/node-dev-simple
 
-Add the generated certificate to the trusted certificate lists on your server.
-Then associate the hostname 'NodeJS' to the docker-machine ip in '/etc/hosts' on Node.js server machine.
+Install the certificate on your TUleap server
+---------------
+
+Add the generated certificate to the trusted certificate lists on your Tuleap server.
 
 .. NOTE:: Please read and follow instructions of :ref:`admin_howto_add_certicate` before continuing.
+
+Then associate the hostname 'NodeJS' to the Node Docker container's ip in '/etc/hosts/ on the Tuleap server.
 
 Install the certificate on the client
 ---------------
 
-Add the certificate on your browser. Then to declare at your browser it uses a correct certificate associate the hostname 'NodeJS' to the docker-machine ip in '/etc/hosts' on your machine.
+Add the certificate on your browser. Then to declare at your browser it uses a correct certificate, associate the hostname 'NodeJS' to the Node Docker container's ip in '/etc/hosts' on your machine.
 
 Create your own config file for Node.js server
 ---------------
@@ -68,7 +72,13 @@ The default config.json file look like:
     }
 
 Create your own config file in '/etc/tuleap-realtime/config.json' for example.
-Generate a private key that will be shared between Node.js server and Tuleap server. Set this private key on config file with the json key "nodejs_server_jwt_private_key".
+Generate a private key that will be shared between Node.js server and Tuleap server:
+
+.. code-block:: bash
+
+    head -c 32 /dev/urandom | base64
+
+Set this private key in your 'config.json' file at the "nodejs_server_jwt_private_key" property.
 Add the path of 'cert.pem' and 'key.pem' files respectively with json keys "full_path_ssl_cert" and "full_path_ssl_key".
 
 .. IMPORTANT:: This private key generated is used by JsonWebToken to permit secure communication between servers.
@@ -77,18 +87,16 @@ Add the path of 'cert.pem' and 'key.pem' files respectively with json keys "full
 Change configurations on Tuleap server
 ---------------
 
-Connect to the Tuleap server and change the 'local.inc' file:
+Connect to the Tuleap server and change the '/etc/tuleap/conf/local.inc' file:
 
 .. code-block:: txt
 
     $nodejs_server = 'NodeJS:4443'
     $nodejs_server_jwt_private_key = <your_private_key_generated>
 
-Then associate the hostname 'NodeJS' to the docker-machine ip in '/etc/hosts/ on Tuleap server machine.
-
 .. NOTE:: To connect to the Tuleap server you can follow instructions of :ref:`protips`.
 
-Run the server Node.js
+Run the Node.js server
 ---------------
 
 Run the Node.js server with your config file argument.
@@ -96,5 +104,5 @@ Run the Node.js server with your config file argument.
 .. code-block:: bash
 
     $ cd tuleap-realtime
-    $ docker run --rm -v "$PWD/":/nodeapp --entrypoint=bash -ti -p 4443:4443 enalean/node-dev-simple
+    $ docker run -it --rm -v "$PWD/":/nodeapp --entrypoint=bash -p 4443:4443 enalean/node-dev-simple
     > node server.js --config='etc/tuleap-realtime/config.json'


### PR DESCRIPTION
A few things aren't clear yet, I'll leave those questions open and maybe amend the PR:

- I deleted the part where we edit `/etc/hosts` in the Node.JS container. I skipped it accidentally when following the instructions and now the real-time works, so I guess it was useless.
- Should we make a volume for `ssl/cert.pem` and `/ssl/key.pem` ? Right now, I have to either make the volume myself when running the container or copy it every time I run it.
- Should we make a volume for `/etc/tuleap-realtime/config.json` ? idem