### PR TITLE
Proposed reverse proxy configuration should not propose SSLv3

### DIFF
--- a/languages/en/administration-guide/howto.rst
+++ b/languages/en/administration-guide/howto.rst
@@ -1368,6 +1368,17 @@ Configure Nginx
         listen 443 ssl;
         ssl_certificate /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;
+        ssl_session_timeout 1d;
+        ssl_session_cache shared:SSL:50m;
+        ssl_session_tickets off;
+
+        # Path to Diffie-Hellman parameter
+        # You can generated the file with openssl dhparam -out /path/to/dhparam.pem 2048
+        ssl_dhparam /path/to/dhparam.pem;
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+        ssl_prefer_server_ciphers on;
 
         # ++ Cache media (not mandatory for reverse proxy)
         location ~* \.(?:js|css|png|gif|eot|woff)$ {


### PR DESCRIPTION
The current reverse proxy configuration uses nginx default SSL/TLS parameters
which are vulnerable to the POODLE attack (CVE-2014-3566), proposes weak ciphers
and does not enable Perfect Forward Secrecy.

The proposed ciphers in this contribution are based on
the Mozilla's Server Side TLS Guidelines [1].

[1] https://wiki.mozilla.org/Security/Server_Side_TLS