### PR TITLE
Updating backup guide

### DIFF
--- a/languages/en/administration-guide/backup.rst
+++ b/languages/en/administration-guide/backup.rst
@@ -17,8 +17,10 @@ Depending on services you use, you will want to stop them before the backup (It 
 
     $ service http stop
     $ service tuleap stop
-    $ service openfire stop
     $ su - gitolite -c "gitolite writable off"
+
+    # Only if you use the openfire Instant Messaging plugin:
+    $ service openfire stop
 
 Don't forget to restart services once the backup is done.
 

--- a/languages/en/administration-guide/backup.rst
+++ b/languages/en/administration-guide/backup.rst
@@ -1,101 +1,63 @@
 Backup/Restore
 ==============
 
-Backup
-------
+Backup Tuleap
+-------------
 
-MySQL data - A cron job is scheduled to run every Sunday morning at
-``00:45``. MySQL data is backed up to disk. The sequence is as follows:
+This documentation is here to help you to set your backup up. Be careful with this, it's just a guide and you will probably want to backup more things
 
-- service mysqld stop
-- move old ``tuleap-bin.index``, ``tuleap-bin.001``, ``sqldump.<last week's date/time>``
-- dump of ``/var/lib/tuleap/backup/mysql/sqldump.<date>.<time>`` /var/lib/mysql
-- service mysqld start
-- reads /etc/my.cnf
-- new tuleap-bin.index created
-- new tuleap-bin.001 created
+If you installed Tuleap on a virtual environment and you are able to use snapshots, the simplest backup solution is to suspend tuleap services and then make a snapshot. Otherwise here are some tips to backup your Tuleap infrastructure:
 
-Database Restore
-----------------
+Suspend services
+````````````````
 
-#. Two files are needed to rebuild. Find the most recent "dump" and "bin"
-   files:
+Depending on services you use, you will want to stop them before the backup (It should guarantee you a consistent backup):
 
 .. code-block:: bash
 
-   $ cd  /var/lib/tuleap/backup/mysql
-   $ ls -lt
-   # Example:
-   # sqldump.080502.004501 (created from cron "dump" every Sunday; mysql is shut down prior to "dump")
-   $ service mysqld stop
-   $ cd  /var/lib
-   $ mv  mysql  mysql.bck
+    $ service http stop
+    $ service tuleap stop
+    $ service openfire stop
+    $ su - gitolite -c "gitolite writable off"
 
-#. Then restore the mysql databases from sqldump.080502.004501.
+Don't forget to restart services once the backup is done.
 
-.. code-block:: bash
+Database backup
+```````````````
 
-   $ tar -vxf tuleap/backup/mysql/sqldump.080502.004501.tar
-
-#. Then, change the ownership and the security context of the directory:
+Tuleap main database is "tuleap", but additionnal databases can be used for plugins. To show them use:
 
 .. code-block:: bash
+   
+    $ mysql -u codendiadm -p -e "show databases;"
 
-   $ chown -R mysql:mysql /var/lib/mysql
-   $ chcon -R system_u:object_r:mysqld_db_t /var/lib/mysql
+Use mysqldump to backup all databases. You can also write a script to backup each database independently:
 
-#. Finish the mysql rebuild by reloading data from tuleap-bin.000001,
-   which contains changes since sqldump.080502.004501 was created.
-   Boot system in single user mode: We don't want anyone trying to
-   update the mysql database before everything has been restored. Before
-   reloading date, you have to update /etc/my.cnf :
-   Replace :
+.. code-block:: bash
+     
+    $ mysqldump -u codendiadm -p --all-databases > mybackup.sql    
 
-   .. code-block:: bash
+Files backup
+````````````
 
-       [client]
-       default-character-set=utf8
+You need to save the following directories (be careful, you need to preserve the correct rights on files):
 
-   by:
+    - /etc/tuleap
+    - /home/codendiadm
+    - /home/users
+    - /home/groups
+    - /var/lib/tuleap
+    - /var/lib/gitolite
+    - /var/lib/mailman
+    
 
-   .. code-block:: bash
+Restore Tuleap
+--------------
 
-       [client]
-       loose-default-character-set=utf8
+As only data were backed up, you first need a Tuleap server to restore them. It can be your old server or a new server you have just installed following the installation guide. Then you will need to:
 
-   And then:
+    - suspend all services
+    - restore databases
+    - restore directories
+    - run a forge upgrade ('/usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update')
 
-   .. code-block:: bash
-
-       service mysqld  start
-       cd  /var/lib/
-       /usr/bin/mysqlbinlog  mysql.bck/tuleap-bin.000001  |  mysql --user=root  -p
-       password: (enter root password)
-
-   No information will display until it's finished.
-
-Rebuild is complete.
-
-Backup/Restore files
---------------------
-
-There are a number of files used for backup and restore of Tuleap.
-
-/var/lib/tuleap/backup/mysql
-
-The three most current files found in this directory are:
-
--  **sqldump.<date>.<time>:** dump of /var/lib/mysql
--  **tuleap-bin.index:** Text file indicating file name to use when
-   restoring mysql data
--  **tuleap-bin.001:** Binary log file used for viewing or piping into
-   a mysql command if rebuilding database
-
-Older files are stored in /var/lib/tuleap/backup/mysql/old
-
-/etc
-
-The file found in this directory is:
-
--  **my.cnf:** This file is read when mysql starts. MySQL variables are
-   set here.


### PR DESCRIPTION
I have juste rewritten the backup page to propose backup guidelines for administrators. We should not rely on the old backup cron anymore and let the user use its own backup tool.

