### PR TITLE
issue #62 Add watch target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-BUILDDIR      = _build
-LANG          = en
+SPHINXOPTS       =
+SPHINXBUILD      = sphinx-build
+SPHINX_AUTOBUILD = sphinx-autobuild
+BUILDDIR         = _build
+LANG             = en
 
 # Internal variables.
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) tmp/$(LANG)
+WATCHOPTS       = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) languages/$(LANG)
 
 .PHONY: help clean html singlehtml linkcheck
 
@@ -59,3 +61,6 @@ linkcheck: pre-build
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
+
+watch-html: pre-build
+	$(SPHINX_AUTOBUILD) -b html $(WATCHOPTS) $(BUILDDIR)/html --port 5000 --open-browser

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ To add a Google Analytics snippet, use the following theme options:
     source venv/bin/activate
     make SPHINXOPTS="-D html_theme=tuleap_org -D html_theme_options.ga_id=UA-XXXXXXXX-Y -D html_theme_options.ga_content_group_index=YYYYYYYYYYY -D html_theme_options.ga_content_group_name=WWWWWWWW" html
     deactivate
+    
+To build the documentation in watch mode:
+
+    source venv/bin/activate
+    make SPHINXOPTS="-D html_theme=tuleap_org" watch-html
+    deactivate
+    
+> A web-server will start, the modifies pages will be rebuilt and reloaded automatically each time you save your work.
 
 Modify/ add to the documentation
 ------------------------

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Set-up your environment
 
     virtualenv venv
     source venv/bin/activate
-    pip install -r requirements.txt
+    pip install -r requirements.txt -r requirements-dev.txt
     deactivate
 
 Build the documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+sphinx-autobuild==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Sphinx==1.7.2
 sphinxcontrib-phpdomain==0.4.1
+sphinx-autobuild==0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 Sphinx==1.7.2
 sphinxcontrib-phpdomain==0.4.1
-sphinx-autobuild==0.7.1


### PR DESCRIPTION
This patch introduces the watch mode for the documentation.

How to test:
--------------

    source venv/bin/activate
    make SPHINXOPTS="-D html_theme=tuleap_org" watch-html

1. A web server starts in watch mode.
2. The doc is partially rebuilt each time you save your work
3. The browser is refreshed with your last changes