### PR TITLE
Add missing links in the Resources menu

### DIFF
--- a/languages/en/_themes/tuleap_org/header.html
+++ b/languages/en/_themes/tuleap_org/header.html
@@ -22,9 +22,11 @@
       <div class="header-menu-item-container">
         <span class="header-menu-item active">Resources</span>
         <nav class="header-submenu">
+          <a class="header-submenu-item" href="https://www.tuleap.org/they-use-and-love-tuleap">Use cases</a>
           <a class="header-submenu-item" href="https://www.tuleap.org/resources/videos-tutorials">Demos, Tutorials</a>
-          <a class="header-submenu-item" href="https://www.tuleap.org/resources/release-notes">Release notes</a>
           <a class="header-submenu-item" href="/">Documentation</a>
+          <a class="header-submenu-item" href="https://training.tuleap.org/channel/5a413ae2990af17d6a223f3a/Tuleap/catalog">Online trainings</a>
+          <a class="header-submenu-item" href="https://www.tuleap.org/resources/release-notes">Release notes</a>
           <a class="header-submenu-item" href="https://tuleap.net/plugins/git/tuleap/tuleap/stable?p=tuleap%2Fstable.git&amp;a=tree">Sources</a>
         </nav>
       </div>


### PR DESCRIPTION
Some links were missing:
- link to Use cases
- link to Online trainings