### PR TITLE
Fix Node version prerequisit

### DIFF
--- a/languages/en/developer-guide/quick-start/run-tuleap.rst
+++ b/languages/en/developer-guide/quick-start/run-tuleap.rst
@@ -13,7 +13,7 @@ respective documentation for installation instructions:
 - make
 - php
 - `scss-lint <https://github.com/brigade/scss-lint/>`_
-- `nodejs <https://nodejs.org/en/>`_ >= v6.x
+- `nodejs <https://nodejs.org/en/>`_ >= v6.x and < 10.x
 - `npm <https://docs.npmjs.com/>`_ >= v6.0
 - `composer <https://getcomposer.org/>`_
 


### PR DESCRIPTION
`npm run watch` seems to fail with Node `10.x` (tested with `10.12.x` and `10.5.x`).

```
plugins/tracker/www/scripts> npm run watch

> tuleap-tracker@0.2.0 watch /Users/Jibidus/Development/Sogilis/Repos/Enalean/tuleap/plugins/tracker/www/scripts
> NODE_ENV=watch $npm_package_config_bin/concurrently --raw --kill-others 'gulp watch' '$npm_package_config_bin/webpack --watch --mode=development' '$npm_package_config_bin/karma start ./karma.conf.js' '$npm_package_config_bin/karma start ./artifact-action-buttons/karma.conf.js' '$npm_package_config_bin/karma start ./workflow-transitions/karma.conf.js'

gulp[44243]: ../src/node_contextify.cc:629:static void node::contextify::ContextifyScript::New(const FunctionCallbackInfo<v8::Value> &): Assertion `args[1]->IsString()' failed.
 1: 0x100033c31 node::Abort() [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 2: 0x100032c77 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, char const*, int, v8::Local<v8::Value>*, node::async_context) [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 3: 0x100058a4b node::contextify::ContextifyScript::New(v8::FunctionCallbackInfo<v8::Value> const&) [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 4: 0x10022822f v8::internal::FunctionCallbackArguments::Call(v8::internal::CallHandlerInfo*) [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 5: 0x1002273c8 v8::internal::MaybeHandle<v8::internal::Object> v8::internal::(anonymous namespace)::HandleApiCallHelper<true>(v8::internal::Isolate*, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::HeapObject>, v8::internal::Handle<v8::internal::FunctionTemplateInfo>, v8::internal::Handle<v8::internal::Object>, v8::internal::BuiltinArguments) [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 6: 0x100226d97 v8::internal::Builtin_Impl_HandleApiCall(v8::internal::BuiltinArguments, v8::internal::Isolate*) [/Users/Jibidus/.nvm/versions/node/v10.5.0/bin/node]
 7: 0x3039303041bd
 8: 0x30393030f27d
 9: 0x30393038b4a0
10: 0x303930313a09
11: 0x303930313a09
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! tuleap-tracker@0.2.0 watch: `NODE_ENV=watch $npm_package_config_bin/concurrently --raw --kill-others 'gulp watch' '$npm_package_config_bin/webpack --watch --mode=development' '$npm_package_config_bin/karma start ./karma.conf.js' '$npm_package_config_bin/karma start ./artifact-action-buttons/karma.conf.js' '$npm_package_config_bin/karma start ./workflow-transitions/karma.conf.js'`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the tuleap-tracker@0.2.0 watch script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/Jibidus/.npm/_logs/2018-11-19T15_30_16_067Z-debug.log
```