### PR TITLE
Move projects management doc in Projects management section

### DIFF
--- a/languages/en/admin.rst
+++ b/languages/en/admin.rst
@@ -16,7 +16,6 @@ Administration guide
    administration-guide/security
    administration-guide/customisations
    administration-guide/howto
-   administration-guide/project-export-import
    administration-guide/advanced-deployments
    administration-guide/distributed-tuleap
    administration-guide/backend-worker

--- a/languages/en/administration-guide/admin-tasks.rst
+++ b/languages/en/administration-guide/admin-tasks.rst
@@ -1,47 +1,6 @@
 Administration Tasks
 ====================
 
-Projects management
--------------------
-
-Projects can have 5 statuses:
-
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-| Status    | What it means                                                                                          | Can it be changed? |
-+===========+========================================================================================================+====================+
-| Pending   | The project is waiting for approval from the site-administrator.                                       | Yes                |
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-| Active    | This project is currently active, some people are working on it.                                       | Yes                |
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-| Suspended | This project isn't accessible anymore by anyone excepted the site-administrator with read access only. | Yes                |
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-| Deleted   | This project has been deleted.                                                                         | No                 |
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-| System    | This project is a system project.                                                                      | No                 |
-+-----------+--------------------------------------------------------------------------------------------------------+--------------------+
-
-.. note::
-    The pending status is meant to be temporary and can not be directly used by administrators.
-
-Suspended projects
-``````````````````
-When a project is ``suspended``, only site-administrators can access it.
-
-In addition to that, all access to its resources are disabled:
-    - CLI operations are blocked for Git and SVN repositories.
-    - REST calls to fetch resources belonging to suspended projects are also blocked and it will result a 403 error.
-    - The services used by this project are blocked.
-
-.. warning::
-    The following services are not blocked and may still be used:
-        - Mailing lists (Lists Service)
-        - Project web pages (Home Page Service)
-        - CVS
-        - SOAP API
-
-This status can be toggled back and forth with no impact on the project. When back to ``active``, all access will be
-unlocked.
-
 Pending users
 -------------
 

--- a/languages/en/administration-guide/customisations.rst
+++ b/languages/en/administration-guide/customisations.rst
@@ -136,10 +136,3 @@ the JSON of this file has to be valid.
 
 Finally, each tour is shown on the page until the user decides to "End" the tour. Upon clicking this, a user will not see a tour
 by that name again.
-
-Project Web Site
-~~~~~~~~~~~~~~~~
-
-.. warning:: Enabling this feature has major security consequences, as such the feature is disabled by default. It is strongly advised to leave it disabled.
-
-When a project is registered on Tuleap a new web site is created for that project. A default home page is installed for that project from the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file. You may want to create your own custom file for your own Tuleap site. To do so, copy the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file in the ``/etc/tuleap/site-content/en_US/others/`` directory if not already there. Then, edit the custom file and customize it to your liking

--- a/languages/en/administration-guide/projects-management.rst
+++ b/languages/en/administration-guide/projects-management.rst
@@ -1,64 +1,10 @@
 Projects management
 ===================
 
-Projects settings
-*****************
+.. toctree::
+   :maxdepth: 1
 
-Categories
-----------
-
-Categorizing projects allows users to better find a particular project (see :ref:`software-map-(or Project Tree)`).
-
-In ``site admin » project settings » categories`` you can define which categories the administrators can use
-for their projects. For each category you can define its description, decide if it is mandatory, choose the maximum
-number of allowed values or choose if it is used as project flag.
-
-.. figure:: ../images/screenshots/siteadmin/edit-category.png
-   :align: center
-   :alt: Screenshot of category edition
-   :name: Screenshot of category edition
-
-   Screenshot of category edition
-
-
-Project flags
-`````````````
-
-In a context of `classified information <https://en.wikipedia.org/wiki/Classified_information>`_, in order to allow
-people to know about the level a project is, this information is displayed in every pages of the project.
-
-Let's consider that project confidentiality is picked-up in one list
-
-* Secret
-* Confidential
-* Restricted
-* Official
-* Unclassified
-
-And another category is used to provide another level of classification
-
-* Personal
-* Special
-* Industry
-
-You can get any combination of the 2 lists:
-
-* Secret - Personal
-* Secret - Industry
-* ...
-
-The information is then displayed on the right hand side of the project name in the navbar with a tooltip with
-full information on hover.
-
-.. figure:: ../images/screenshots/siteadmin/project-flag.png
-   :align: center
-   :alt: Example of project flags
-   :name: Example of project flags
-
-   Example of project flags
-
-.. IMPORTANT::
-   Please note the following constraints for project flags:
-
-   * Up to two categories can be used as project flag
-   * Chosen categories cannot have a maximum number of allowed values bigger than 1.
+   projects-management/project-status
+   projects-management/projects-settings
+   projects-management/project-export-import
+   projects-management/project-website

--- a/languages/en/administration-guide/projects-management/project-export-import.rst
+++ b/languages/en/administration-guide/projects-management/project-export-import.rst
@@ -95,7 +95,7 @@ Comments column should give you all needed information about current status.
 
     The following diagram explains how the décision is made while parsing the users.xml:
 
-    .. figure:: ../images/diagrams/mapping-users-during-project-import.png
+    .. figure:: ../../images/diagrams/mapping-users-during-project-import.png
        :align: center
        :alt: Agile Dashboard Configuration
        :name: Agile Dashboard Configuration

--- a/languages/en/administration-guide/projects-management/project-status.rst
+++ b/languages/en/administration-guide/projects-management/project-status.rst
@@ -1,0 +1,40 @@
+Project status
+==============
+
+Projects can have 5 statuses:
+
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+| Status    | What it means                                                                                          | Can it be changed? |
++===========+========================================================================================================+====================+
+| Pending   | The project is waiting for approval from the site-administrator.                                       | Yes                |
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+| Active    | This project is currently active, some people are working on it.                                       | Yes                |
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+| Suspended | This project isn't accessible anymore by anyone excepted the site-administrator with read access only. | Yes                |
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+| Deleted   | This project has been deleted.                                                                         | No                 |
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+| System    | This project is a system project.                                                                      | No                 |
++-----------+--------------------------------------------------------------------------------------------------------+--------------------+
+
+.. note::
+    The pending status is meant to be temporary and can not be directly used by administrators.
+
+Suspended projects
+``````````````````
+When a project is ``suspended``, only site-administrators can access it.
+
+In addition to that, all access to its resources are disabled:
+    - CLI operations are blocked for Git and SVN repositories.
+    - REST calls to fetch resources belonging to suspended projects are also blocked and it will result a 403 error.
+    - The services used by this project are blocked.
+
+.. warning::
+    The following services are not blocked and may still be used:
+        - Mailing lists (Lists Service)
+        - Project web pages (Home Page Service)
+        - CVS
+        - SOAP API
+
+This status can be toggled back and forth with no impact on the project. When back to ``active``, all access will be
+unlocked.

--- a/languages/en/administration-guide/projects-management/project-website.rst
+++ b/languages/en/administration-guide/projects-management/project-website.rst
@@ -1,0 +1,7 @@
+Project Web Site
+~~~~~~~~~~~~~~~~
+
+.. danger:: Enabling this feature **has major security consequences**, as such the feature is disabled by default.
+   It is strongly advised to leave it disabled.
+
+When a project is registered on Tuleap a new web site is created for that project. A default home page is installed for that project from the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file. You may want to create your own custom file for your own Tuleap site. To do so, copy the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file in the ``/etc/tuleap/site-content/en_US/others/`` directory if not already there. Then, edit the custom file and customize it to your liking

--- a/languages/en/administration-guide/projects-management/projects-settings.rst
+++ b/languages/en/administration-guide/projects-management/projects-settings.rst
@@ -1,0 +1,61 @@
+Projects settings
+*****************
+
+Categories
+----------
+
+Categorizing projects allows users to better find a particular project (see :ref:`software-map-(or Project Tree)`).
+
+In ``site admin » project settings » categories`` you can define which categories the administrators can use
+for their projects. For each category you can define its description, decide if it is mandatory, choose the maximum
+number of allowed values or choose if it is used as project flag.
+
+.. figure:: ../../images/screenshots/siteadmin/edit-category.png
+   :align: center
+   :alt: Screenshot of category edition
+   :name: Screenshot of category edition
+
+   Screenshot of category edition
+
+
+Project flags
+`````````````
+
+In a context of `classified information <https://en.wikipedia.org/wiki/Classified_information>`_, in order to allow
+people to know about the level a project is, this information is displayed in every pages of the project.
+
+Let's consider that project confidentiality is picked-up in one list
+
+* Secret
+* Confidential
+* Restricted
+* Official
+* Unclassified
+
+And another category is used to provide another level of classification
+
+* Personal
+* Special
+* Industry
+
+You can get any combination of the 2 lists:
+
+* Secret - Personal
+* Secret - Industry
+* ...
+
+The information is then displayed on the right hand side of the project name in the navbar with a tooltip with
+full information on hover.
+
+.. figure:: ../../images/screenshots/siteadmin/project-flag.png
+   :align: center
+   :alt: Example of project flags
+   :name: Example of project flags
+
+   Example of project flags
+
+.. IMPORTANT::
+   Please note the following constraints for project flags:
+
+   * Up to two categories can be used as project flag
+   * Chosen categories cannot have a maximum number of allowed values bigger than 1.


### PR DESCRIPTION
In order to better organize administration guide, I suggested in
fe0b81ce1abdac0481b69aac0ce4295e5189dddf to have Projects management,
Users management, … sections.

This commit move some existing content in Projects management section.