### PR TITLE
Fix for Sphinx rendering in backup documentation

### DIFF
--- a/languages/en/administration-guide/system-administration/backup.rst
+++ b/languages/en/administration-guide/system-administration/backup.rst
@@ -61,4 +61,4 @@ As only data were backed up, you first need a Tuleap server to restore them. It 
     - suspend all services
     - restore databases
     - restore directories
-    - run a forge upgrade ('/usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update')
+    - run a forge upgrade ``/usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update``


### PR DESCRIPTION
When rendered in Sphinx , copy/paste from the Backup/Restore documentation is not working for this command as the double hyphens are misrendered.
`/usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update`

This pull request fixes that little issue.