### PR TITLE
Add "Deprecations" page

### DIFF
--- a/languages/en/deploy.rst
+++ b/languages/en/deploy.rst
@@ -4,4 +4,5 @@ Deployment guide
 .. toctree::
    :maxdepth: 1
 
+   deployment-guide/deprecations
    deployment-guide/intro

--- a/languages/en/deployment-guide/deprecations.rst
+++ b/languages/en/deployment-guide/deprecations.rst
@@ -1,0 +1,59 @@
+Deprecations and end of support
+===============================
+
+Here is the list of what Tuleap will remove, stop or start supporting with the
+planned time periods.
+
+==================================================== ================= =============================================
+Q3 2019                                              Status            As platform administrator, what should I do ?
+==================================================== ================= =============================================
+Legacy GitPHP web interface                          Removed           Nothing
+Legacy Tracker Workflows configuration web interface Removed           Nothing
+MySQL versions < 5.7                                 End of support    Upgrade to Mysql 5.7 or higher
+RabbitMQ (replaced by Redis)                         Replaced by Redis Uninstall RabbitMQ
+WebDAV with Windows 7 client                         End of support    End-users should switch to Cyberduck
+PHP 7.3                                              Start of support  (Optionally switch to PHP 7.3)
+Internet Explorer 11                                 End of support    End-users should switch to Chrome or Firefox
+                                                     for new features
+==================================================== ================= =============================================
+
+=============================== ================= =============================================
+Q4 2019                         Status            As platform administrator, what should I do ?
+=============================== ================= =============================================
+Codendi CLI                     End of support    Switch to Tuleap CLI
+PHP 7.2                         End of support    Switch to PHP 7.3
+GitShell backend for Git plugin Removed           End-users should push to Gitolite repository
+Gerrit versions < 2.12          End of support    Switch to Gerrit 2.12
+Mysql 8                         Start of support  (Optionally switch to Mysql 8)
+Realtime server using NodeJS    Replaced          (To be announced)
+RHEL 6                          End of support    Switch to RHEL 7
+tab file-based translations     Replaced by       Nothing
+                                gettext
+=============================== ================= =============================================
+
+======= ================= =============================================
+S1 2020 Status            As platform administrator, what should I do ?
+======= ================= =============================================
+PHP 7.4 Start of support  (Optionally switch to PHP 7.4)
+RHEL 8  Start of support  (optionally switch to RHEL 8)
+======= ================= =============================================
+
+==================== =============== =============================================
+S2 2020              Status          As platform administrator, what should I do ?
+==================== =============== =============================================
+PHP 7.3              End of support  Switch to PHP 7.4
+Internet Explorer 11 End of support  End-users should switch to Chrome or Firefox
+==================== =============== =============================================
+
+========= =============== =============================================
+2021      Status          As platform administrator, what should I do ?
+========= =============== =============================================
+MySQL 5.7 End of support  Switch to MySQL 8
+========= =============== =============================================
+
+=========== ======== =============================================
+The Future  Status   As platform administrator, what should I do ?
+=========== ======== =============================================
+SOAP API    Removed  End-users should switch to REST API
+Trackers v3 Removed  Migrate to Trackers v5
+=========== ======== =============================================

--- a/languages/en/deployment-guide/deprecations.rst
+++ b/languages/en/deployment-guide/deprecations.rst
@@ -4,26 +4,26 @@ Deprecations and end of support
 Here is the list of what Tuleap will remove, stop or start supporting with the
 planned time periods.
 
-==================================================== ================= =============================================
+==================================================== ================= ==============================================
 Q3 2019                                              Status            As platform administrator, what should I do ?
-==================================================== ================= =============================================
+==================================================== ================= ==============================================
 Legacy GitPHP web interface                          Removed           Nothing
 Legacy Tracker Workflows configuration web interface Removed           Nothing
 MySQL versions < 5.7                                 End of support    Upgrade to Mysql 5.7 or higher
 RabbitMQ (replaced by Redis)                         Replaced by Redis Uninstall RabbitMQ
 WebDAV with Windows 7 client                         End of support    End-users should switch to Cyberduck
 PHP 7.3                                              Start of support  (Optionally switch to PHP 7.3)
-Internet Explorer 11                                 End of support    End-users should switch to Chrome or Firefox
-                                                     for new features
-==================================================== ================= =============================================
+Internet Explorer 11                                 End of support    New features won't be usable with IE 11.
+                                                                       End-users should switch to Firefox or Chrome
+==================================================== ================= ==============================================
 
 =============================== ================= =============================================
 Q4 2019                         Status            As platform administrator, what should I do ?
 =============================== ================= =============================================
-Codendi CLI                     End of support    Switch to Tuleap CLI
+Codendi CLI                     End of support    Use REST API
 PHP 7.2                         End of support    Switch to PHP 7.3
 GitShell backend for Git plugin Removed           End-users should push to Gitolite repository
-Gerrit versions < 2.12          End of support    Switch to Gerrit 2.12
+Gerrit versions < 2.12          End of support    Switch to Gerrit 2.16 or higher
 Mysql 8                         Start of support  (Optionally switch to Mysql 8)
 Realtime server using NodeJS    Replaced          (To be announced)
 RHEL 6                          End of support    Switch to RHEL 7
@@ -35,14 +35,14 @@ tab file-based translations     Replaced by       Nothing
 S1 2020 Status            As platform administrator, what should I do ?
 ======= ================= =============================================
 PHP 7.4 Start of support  (Optionally switch to PHP 7.4)
-RHEL 8  Start of support  (optionally switch to RHEL 8)
+RHEL 8  Start of support  (Optionally switch to RHEL 8)
 ======= ================= =============================================
 
 ==================== =============== =============================================
 S2 2020              Status          As platform administrator, what should I do ?
 ==================== =============== =============================================
 PHP 7.3              End of support  Switch to PHP 7.4
-Internet Explorer 11 End of support  End-users should switch to Chrome or Firefox
+Internet Explorer 11 End of support  End-users should switch to Firefox or Chrome
 ==================== =============== =============================================
 
 ========= =============== =============================================
@@ -51,9 +51,11 @@ Internet Explorer 11 End of support  End-users should switch to Chrome or Firefo
 MySQL 5.7 End of support  Switch to MySQL 8
 ========= =============== =============================================
 
-=========== ======== =============================================
-The Future  Status   As platform administrator, what should I do ?
-=========== ======== =============================================
-SOAP API    Removed  End-users should switch to REST API
-Trackers v3 Removed  Migrate to Trackers v5
-=========== ======== =============================================
+===================== ======== =============================================
+The Future            Status   As platform administrator, what should I do ?
+===================== ======== =============================================
+SOAP API              Removed  End-users should switch to REST API
+Trackers v3           Removed  Migrate to Trackers v5
+Subversion (SVN Core) Removed  Switch to SVN Plugin
+PHP Wiki              Removed  Switch to Mediawiki
+===================== ======== =============================================


### PR DESCRIPTION
This page will list all planned deprecations but also planned versions
support. It should help platform administrators anticipate future
deployments and share a vision of which technologies will be dropped and
when.