### PR TITLE
Increase minimum required nodejs version to v8

### DIFF
--- a/languages/en/developer-guide/quick-start/run-tuleap.rst
+++ b/languages/en/developer-guide/quick-start/run-tuleap.rst
@@ -12,8 +12,8 @@ respective documentation for installation instructions:
 
 - make
 - php
-- `nodejs <https://nodejs.org/en/>`_ >= v6.x
-- `npm <https://docs.npmjs.com/>`_ >= v6.0
+- `nodejs <https://nodejs.org/en/>`_ >= v8.x
+- `npm <https://docs.npmjs.com/>`_ >= v6.11.x
 - `composer <https://getcomposer.org/>`_
 
    .. IMPORTANT:: By default, composer installs itself in the local directory as ``composer.phar``.


### PR DESCRIPTION
As part of https://tuleap.net/plugins/tracker/?aid=13775, most of our dev dependencies have dropped support for Nodejs v6.
As you can see on https://nodejs.org/en/about/releases/, Nodejs v6 has reached its end of life and is no longer maintained.