### PR TITLE
Remove the "popular" links on the index page of tuleap_org theme

### DIFF
--- a/languages/en/_themes/tuleap_org/index.html
+++ b/languages/en/_themes/tuleap_org/index.html
@@ -46,15 +46,4 @@
             </a>
         </div>
     </div>
-
-    <div class="doc-populars">
-        <h2 class="doc-homepage-subtitle">Populars</h2>
-        <ul>
-            <li class="doc-popular"><a href="{{ pathto('developer-guide/quick-start') }}">Developer quick start</a></li>
-            <li class="doc-popular"><a href="{{ pathto('developer-guide/release') }}">Tuleap release process</a></li>
-            <li class="doc-popular"><a href="{{ pathto('installation-guide/docker-image') }}">Docker image</a></li>
-            <li class="doc-popular"><a href="{{ pathto('developer-guide/coding-standards') }}">Tuleap coding standards</a></li>
-            <li class="doc-popular"><a href="{{ pathto('user-guide/overview') }}">Tuleap Overview</a></li>
-        </ul>
-    </div>
 </div>

--- a/languages/en/_themes/tuleap_org/style/_doc.scss
+++ b/languages/en/_themes/tuleap_org/style/_doc.scss
@@ -481,10 +481,6 @@ body {
             margin: 0 100px 0 0;
         }
     }
-
-    > .doc-populars {
-        flex: 0 0 auto;
-    }
 }
 
 .doc-guides {
@@ -507,16 +503,6 @@ body {
         @media screen and (min-width: #{$big-screen-size}) {
             width: 280px;
         }
-    }
-}
-
-.doc-popular {
-    margin: 0 0 5px;
-
-    &::before {
-        content: '\f1cd';
-        top: -1px;
-        font-size: 14px;
     }
 }
 


### PR DESCRIPTION
Out of the 5 hardcoded links that has been put in this section:
 * 3 are about things that only concern Tuleap contributors (i.e. probably not the
most popular content)
 * 1 is broken

In the current state not having this section at all probably brings the same value.