### PR TITLE
Remove broken link to GeSHi syntax hightlighting page

### DIFF
--- a/languages/en/user-guide/documents-and-files/mediawiki.rst
+++ b/languages/en/user-guide/documents-and-files/mediawiki.rst
@@ -100,7 +100,7 @@ Tuleap currently integrates the following Mediawiki extensions:
 * `PdfBook <https://www.mediawiki.org/wiki/Extension:PdfBook>`_ : lets you compose a book from articles in a category and export it as PDF.
 
 * `SyntaxHighlight_GeSHi <https://www.mediawiki.org/wiki/Extension:SyntaxHighlight_GeSHi>`_ : allows for source code syntax highlighting throught the ``<syntaxhighlight>`` tag
-  and the `GeSHi syntax highlighting <http://qbnz.com/highlighter/>`_.
+  and the GeSHi syntax highlighting.
 
 * `WikiEditor <https://www.mediawiki.org/wiki/Extension:WikiEditor>`_ : provides a text editor. Only available when display is 'Compatibility view' mode (see below).
 


### PR DESCRIPTION
The page seems to be down and it does not seem to exist a good alternative to it.
Information on the page were quite limited anyway.