### PR TITLE
Search result links are broken when the docs.tuleap.org theme is used

### DIFF
--- a/languages/en/_themes/tuleap_org/layout.html
+++ b/languages/en/_themes/tuleap_org/layout.html
@@ -136,24 +136,12 @@
     {% include "footer.html" %}
   </main>
 
-  {% if not embedded %}
-    <script type="text/javascript">
-        var DOCUMENTATION_OPTIONS = {
-            URL_ROOT:'{{ url_root }}',
-            VERSION:'{{ release|e }}',
-            COLLAPSE_INDEX:false,
-            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }},
-            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
-        };
-    </script>
-  {% endif %}
-
   {%- for scriptfile in script_files %}
     <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
   {%- endfor %}
   {%- block scripts %}
 
+  <script id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
   <script src="{{ pathto('_static/assets/scroll.js', 1) }}" charset="utf-8"></script>
   <script src="{{ pathto('_static/assets/nav.js', 1) }}" charset="utf-8"></script>
   <script src="{{ pathto('_static/assets/theme.js', 1) }}" charset="utf-8"></script>

--- a/languages/en/_themes/tuleap_org/static/documentation_options.js_t
+++ b/languages/en/_themes/tuleap_org/static/documentation_options.js_t
@@ -1,0 +1,12 @@
+var DOCUMENTATION_OPTIONS = {
+    URL_ROOT: document.getElementById("documentation_options").getAttribute('data-url_root'),
+    VERSION: '{{ release|e }}',
+    LANGUAGE: '{{ language }}',
+    COLLAPSE_INDEX: false,
+    BUILDER: '{{ builder }}',
+    FILE_SUFFIX: '{{ file_suffix }}',
+    LINK_SUFFIX: '{{ link_suffix }}',
+    HAS_SOURCE: {{ has_source|lower }},
+    SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
+    NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}}
+};


### PR DESCRIPTION
The documentation options are now loaded via a dedicated script like in
the Sphinx basic theme [0].

[0] https://github.com/sphinx-doc/sphinx/blob/v3.0.0/sphinx/themes/basic/layout.html#L90