### PR TITLE
Adapt paths to core build unification

### DIFF
--- a/languages/en/developer-guide/back-end/widgets.rst
+++ b/languages/en/developer-guide/back-end/widgets.rst
@@ -49,23 +49,23 @@ You create the MyWelcomeMessage.php file in src/common/widget with following con
                 parent::__construct(self::NAME);
             }
 
-            public function getTitle() : string
+            public function getTitle(): string
             {
                 return _('Welcome aboard');
             }
 
-            public function getDescription() : string
+            public function getDescription(): string
             {
                 return _('Welcome message and information for users');
             }
 
-            public function getContent() : string
+            public function getContent(): string
             {
                 return 'Welcome';
             }
         }
 
-and run `make autoload-docker` to refresh autoload files.
+and run `make composer` to refresh autoload files.
 
 Step 2: Reference the widget
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,19 +106,22 @@ It's becoming common to have complicated widgets with lots of user interaction. 
 .. code-block:: php
 
     /** src/common/widget/MyWelcomeMessage.php */
-    public function getJavascriptDependencies() : array
+    public function getJavascriptDependencies(): array
     {
-        $kanban_include_assets = new IncludeAssets(
-            __DIR__. '/../../../../src/www/assets/agiledashboard/scripts',
-            '/assets/agiledashboard/scripts/'
-        );
-        $ckeditor_path = '/scripts/ckeditor-4.3.2/';
+        $assets = $this->getAssets();
+        return [
+            ['file' => $assets->getFileURL('angular.js'), 'unique-name' => 'angular'],
+            ['snippet' => 'window.CKEDITOR_BASEPATH = "' . $ckeditor_path . '";'],
+            ['file' => $ckeditor_path . 'ckeditor.js'],
+            ['file' => $assets->getFileURL('kanban.js')],
+        ];
+    }
 
-        return array(
-            array('file' => $kanban_include_assets->getFileURL('angular.js'), 'unique-name' => 'angular'),
-            array('snippet' => 'window.CKEDITOR_BASEPATH = "' . $ckeditor_path . '";'),
-            array('file' => $ckeditor_path . 'ckeditor.js'),
-            array('file' => $kanban_include_assets->getFileURL('kanban.js')),
+    public function getAssets(): IncludeAssets
+    {
+        return new IncludeAssets(
+            __DIR__. '/../../www/assets/agiledashboard',
+            '/assets/agiledashboard'
         );
     }
 
@@ -127,14 +130,9 @@ The previous code block shows an example with the Kanban widget. It returns an a
 .. code-block:: php
 
     /** src/common/widget/MyWelcomeMessage.php */
-    public function getStylesheetDependencies() : CssAssetCollection
+    public function getStylesheetDependencies(): CssAssetCollection
     {
-        $theme_include_assets = new IncludeAssets(
-            __DIR__ . '/../../../www/themes/BurningParrot/assets',
-            AGILEDASHBOARD_BASE_URL . '/themes/BurningParrot/assets'
-        );
-
-        return new CssAssetCollection([new CssAsset($include_assets, 'kanban')]);
+        return new CssAssetCollection([new CssAsset($this->getAssets(), 'kanban')]);
     }
 
 The previous code block shows an example, again with the Kanban widget. It returns a ``CssAssetCollection`` object which helps to deduplicate CSS files. That way, if there are two identical widgets on the same dashboard, their CSS will be loaded only once.

--- a/languages/en/developer-guide/front-end/css.rst
+++ b/languages/en/developer-guide/front-end/css.rst
@@ -9,23 +9,41 @@ SCSS files are just extended CSS files. It means you can use variables, function
 
 Please refer to the `Sass documentation <https://sass-lang.com/documentation>`_ for more information.
 
+SCSS files should always go in "themes" folders.
+
+* For the core, it should go in ``src/themes/BurningParrot/css/``
+* For plugins, it should go in ``plugins/<my-plugin>/themes/BurningParrot/``
+
 Compile SCSS files
 ------------------
 
 From the root directory of the Tuleap sources (you must have npm installed):
 
-.. code-block:: bash
+    .. code-block:: bash
 
-   $ npm install
-   $ npm run build
+        $ npm install
+        $ npm run build
 
 This command will compile all SCSS files present in ``plugin`` and ``src`` directories.
 
-.. important::
+    .. important::
 
-    * you have to run ``npm run build`` everytime you edit a SCSS file.
-    * you can use ``npm run watch`` to automatically rebuild CSS after changes.
-    * CSS files will be git-ignored so there is no use in modifying them.
+        * you have to run ``npm run build`` everytime you edit a SCSS file.
+        * CSS files will be git-ignored so there is no use in modifying them.
+
+
+If you are working in Tuleap "core", change your current directory to ``src/`` to run the "npm" commands.
+If you are working in a plugin for Tuleap, change your current directory to the "root" of that plugin in ``plugins/<my-plugin>/`` to run the "npm" commands.
+
+While you are working, the following command should help you:
+
+    .. code-block:: bash
+
+        $ npm run watch
+
+    .. important::
+
+        ``npm run watch`` will automatically rebuild CSS after changes.
 
 Best practices for Tuleap
 -------------------------
@@ -49,12 +67,12 @@ Rules best practices
 * Always prefix class names by the plugin (or the general view) you are in. For example, when working in the Git plugin, prefix all class names with "git-"
 * Use naming to indicate where the selector is. For example:
 
-  .. code-block:: html
+    .. code-block:: html
 
     <div class="git-repository-list">
         <section class="git-repository-card">
-        	<div class="git-repository-card-header">
-        	<!-- ... -->
+            <div class="git-repository-card-header">
+            <!-- ... -->
 
   The long names help us avoid name-clashing with another plugin and help get a sense of where the rule is applied when reading Sass files.
 * Don't use the `descendant combinator`_, for example ".class1 .class2". It hurts performances because when the browser gets to "class2", it will have to recursively find all its ancestors to see if they are "class1".

--- a/languages/en/developer-guide/front-end/javascript.rst
+++ b/languages/en/developer-guide/front-end/javascript.rst
@@ -7,7 +7,7 @@ New code must be written in `Typescript <https://www.typescriptlang.org/>`_.
 
 Typescript code should always go in "scripts" folders.
 
-* For the core, it should go in ``src/www/scripts/``
+* For the core, it should go in ``src/scripts/``
 * For plugins, it should go in ``plugins/<my-plugin>/scripts/``
 
 Build the typescript files
@@ -27,7 +27,7 @@ This command will install the tools needed, transpile the javascript to make it 
 		* you have to run ``npm run build`` every time you edit a Javascript file.
 		* Built javascript files go to the "assets" folder. You should never modify files in "assets" folders as they are removed when you rebuild.
 
-If you are working in Tuleap "core", change your current directory to ``src/www/scripts/`` to run the "npm" commands.
+If you are working in Tuleap "core", change your current directory to ``src/`` to run the "npm" commands.
 If you are working in a plugin for Tuleap, change your current directory to the "root" of that plugin in ``plugins/<my-plugin>/`` to run the "npm" commands.
 
 While you are working, the following commands should help you:


### PR DESCRIPTION
Following https://tuleap.net/plugins/tracker/?aid=14752, Tuleap Core
follows the same structure as plugins where webpack.common.js is at the
root of src/ and builds both scripts and themes.
The dev guide has been updated to reflect that.