### PR TITLE
Mention migration to PHPRedis 5 in the migration guide

### DIFF
--- a/languages/en/administration-guide/system-administration/advanced-deployments.rst
+++ b/languages/en/administration-guide/system-administration/advanced-deployments.rst
@@ -307,7 +307,7 @@ Install Redis server from epel repository
 
 .. code-block:: bash
 
-   $ sudo yum install -y redis php56-php-pecl-redis
+   $ sudo yum install -y redis
 
 Generate a strong password ``${REDIS_PASSWORD}`` and set in the configuration:
 
@@ -613,13 +613,7 @@ Tuleap service is an umbrella unit and start the following services
 Finalize configuration on el6 server
 ''''''''''''''''''''''''''''''''''''
 
-Install php redis connector:
-
-.. code-block:: bash
-
-   $ sudo yum install -y php-pecl-redis php-amqplib-amqplib
-
-Then edit ``/etc/httpd/conf.d/php.conf`` and update:
+Edit ``/etc/httpd/conf.d/php.conf`` and update:
 
 .. code-block:: apacheconf
 

--- a/languages/en/deployment-guide/11.x.rst
+++ b/languages/en/deployment-guide/11.x.rst
@@ -8,6 +8,22 @@ Tuleap 11.14
 
   Tuleap 11.14 is currently under development.
 
+Update to PHP Redis 5
+---------------------
+
+Until now was depending on PHP Redis 4. To do the upgrade you will first need to remove it:
+
+.. sourcecode:: shell
+
+    #> yum shell -y <<EOF
+    remove php73-php-pecl-redis4
+    update
+    run
+    quit
+    EOF
+
+The rest of the upgrade must follow the same :ref:`update instructions <update>` as usual.
+
 New upgrade command
 -------------------
 


### PR DESCRIPTION
Also removed all direct installations of the extension since it is now a
dependency of the main Tuleap package.