### PR TITLE
Mention explicitely that TTM tab in the agile dashboard is gone

### DIFF
--- a/languages/en/deployment-guide/11.x.rst
+++ b/languages/en/deployment-guide/11.x.rst
@@ -16,6 +16,8 @@ between the :ref:`Agile Dashboard <agile-dashboard>` and the :ref:`Test Manageme
 
 To get it, install the `tuleap-plugin-testplan` package and activate it in the site
 administration. For more information about plugins installation, see :ref:`install-plugins`.
+The previous integration has been removed, so if you were using it you will need to install the
+new Test Plan.
 
 This new plugin is part of :ref:`Tuleap Entreprise <tuleap-enterprise>`.
 


### PR DESCRIPTION
The Test Plan plugin should be installed if the integration was used.

Part of story #14882: Create new campaign in new “Test” screen