### PR TITLE
Add instructions in the deployment guide to give access to plugin_openidconnectclient_user_mapping to dbauthuser

### DIFF
--- a/languages/en/deployment-guide/12.x.rst
+++ b/languages/en/deployment-guide/12.x.rst
@@ -8,6 +8,25 @@ Tuleap 12.1
 
   Tuleap 12.1 is currently under development.
 
+OpenID Connect and Subversion
+-----------------------------
+
+This is the continuation of the work initiated in Tuleap 12.0: accounts connected to an OpenID Connect provider must
+use :ref:`SVN Tokens <svn-plugin-use-token>` to access SVN repositories.
+
+In order to enforce this change, it is necessary to allow the DB user used to handle SVN authentications more access to the
+database. **These changes are mandatory even if your Tuleap instance does not use the OpenID Connect plugin.**
+You must run the following commands on your database with a privileged user:
+
+.. sourcecode:: sql
+
+        GRANT CREATE,SELECT ON plugin_ldap_user TO dbauthuser;
+        GRANT CREATE,SELECT ON plugin_openidconnectclient_user_mapping TO dbauthuser;
+        REVOKE CREATE ON plugin_ldap_user FROM dbauthuser;
+        REVOKE CREATE ON plugin_openidconnectclient_user_mapping FROM dbauthuser;
+        FLUSH PRIVILEGES;
+
+
 Tuleap 12.0
 ===========
 


### PR DESCRIPTION
[request #16681](https://tuleap.net/plugins/tracker/?aid=16681): OIDC accounts must use SVN tokens