### PR TITLE
Adding Gerrit 3.0 to the list of end of support for S2 2020

### DIFF
--- a/languages/en/deploy.rst
+++ b/languages/en/deploy.rst
@@ -53,6 +53,7 @@ Realtime server using NodeJS  Replaced          (To be announced)
 PHP 7.3                       End of support    Switch to PHP 7.4
 Internet Explorer 11          End of support    End-users should switch to Firefox or Chrome
 RHEL 8                        Start of support  (Optionally switch to RHEL 8)
+Gerrit versions < 3.1         End of support    Switch to Gerrit 3.1 or higher
 ============================= ================= =============================================
 
 ========= =============== =============================================


### PR DESCRIPTION
Gerrit 3.3 release is planned for [November 9](https://www.gerritcodereview.com/2020-09-07-gerrit-3.3-release-plan.html) meaning that Gerrit 3.0 will be EOLed upstream.