### PR TITLE
Renew ansible-tuleap documentation

### DIFF
--- a/languages/en/installation-guide/ansible-installation.rst
+++ b/languages/en/installation-guide/ansible-installation.rst
@@ -21,7 +21,7 @@ Then you will need on your own computer or on a server an ansible client. See in
 Ansible Role
 ------------
 
-Get the ansible role from github: https://github.com/Enalean/ansible-tuleap
+Get the Ansible role from GitHub: https://github.com/Enalean/ansible-tuleap
 
 
 Installation

--- a/languages/en/installation-guide/ansible-installation.rst
+++ b/languages/en/installation-guide/ansible-installation.rst
@@ -44,8 +44,8 @@ Then you can create your playbook:
     - hosts: tuleap-serv
       become: yes
       roles:
-# On the next line, replace the path by the path were you retrieved the role and uncomment it
-#        - role: /path/to/ansible-tuleap/role
+      # On the next line, replace the path by the path were you retrieved the role and uncomment it
+      # - role: /path/to/ansible-tuleap/role
       vars:
         tuleap_admin_email:      admin@tuleap.example.com
         tuleap_packages_state:   latest

--- a/languages/en/installation-guide/ansible-installation.rst
+++ b/languages/en/installation-guide/ansible-installation.rst
@@ -21,13 +21,7 @@ Then you will need on your own computer or on a server an ansible client. See in
 Ansible Role
 ------------
 
-Install the Tuleap role for ansible with ansible galaxy:
-
-::
-
-    $ ansible-galaxy install Enalean.Tuleap
-
-You can find the description of the role here: https://galaxy.ansible.com/Enalean/Tuleap/
+Get the ansible role from github: https://github.com/Enalean/ansible-tuleap
 
 
 Installation
@@ -39,27 +33,22 @@ Create an inventory referencing your tuleap servers and describing the tuleap_do
 
 ::
 
-    [tuleap-test]
-    mytestserver1 tuleap_domain=tuleap-test1.example.com
-    mytestserver2 tuleap_domain=tuleap-test2.example.com
-
-    [tuleap-prod]
-    tuleap.example.com tuleap_domain=tuleap.example.com
+    [tuleap-serv]
+    tuleap.example.com tuleap_fqdn=tuleap.example.com
 
 
 Then you can create your playbook:
 
 ::
 
-    - hosts: tuleap-test
-      remote_user: root
+    - hosts: tuleap-serv
+      become: yes
       roles:
-        - { role: Enalean.Tuleap, tuleap_version=master }
-
-    - hosts: tuleap-prod
-      remote_user: root
-      roles:
-        - { role: Enalean.Tuleap, tuleap_version=stable }
+        - role: ansible-tuleap
+      vars:
+        tuleap_admin_email:      admin@tuleap.example.com
+        tuleap_packages_state:   latest
+        tuleap_generate_le_cert: True
 
 Execute your playbook to deploy your servers:
 

--- a/languages/en/installation-guide/ansible-installation.rst
+++ b/languages/en/installation-guide/ansible-installation.rst
@@ -44,7 +44,8 @@ Then you can create your playbook:
     - hosts: tuleap-serv
       become: yes
       roles:
-        - role: ansible-tuleap
+# On the next line, replace the path by the path were you retrieved the role and uncomment it
+#        - role: /path/to/ansible-tuleap/role
       vars:
         tuleap_admin_email:      admin@tuleap.example.com
         tuleap_packages_state:   latest


### PR DESCRIPTION
I updated the ansible role to install Tuleap, and the documentation needs a refresh