### PR TITLE
request #17114: Setup cross-origin isolation when loading the documentation

### DIFF
--- a/docs.tuleap.org/nginx.conf
+++ b/docs.tuleap.org/nginx.conf
@@ -34,6 +34,9 @@ http {
         add_header X-XSS-Protection '1; mode=block' always;
         add_header X-Content-Type-Options 'nosniff' always;
         add_header Referrer-Policy 'no-referrer' always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+        add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
 
         location / {
             root   /usr/share/nginx/html;


### PR DESCRIPTION
This change is the equivalent on docs.tuleap.org of git #tuleap/stable/7971b7c35005d428fe3109955744c81fee3e999a.