### PR TITLE
Platform banner is defined through the web interface

### DIFF
--- a/languages/en/administration-guide/application-management/motd.rst
+++ b/languages/en/administration-guide/application-management/motd.rst
@@ -1,9 +1,9 @@
-MOTD
-----
+.. _platform-banner:
 
-You can define a message of the day that will appear at the top of the page of each user, connected or not to the platform.
+Platform banner
+===============
 
-The message should be defined, according to the language, in:
+You can define a message (formerly known as MOTD) that will appear at the top of the page of
+each user, connected or not to the platform.
 
-* /etc/tuleap/site-content/en_US/others/motd.txt
-* /etc/tuleap/site-content/fr_FR/others/motd.txt
+The message can be defined by site administrators in admin » global configuration » platform banner.

--- a/languages/en/deployment-guide/12.x.rst
+++ b/languages/en/deployment-guide/12.x.rst
@@ -8,6 +8,18 @@ Tuleap 12.2
 
   Tuleap 12.2 is currently under development.
 
+MOTD becomes Platform banner
+----------------------------
+
+When you had to display a message to all users, you were used to edit
+file ``/etc/tuleap/site-content/en_US/others/motd.txt``. Now you have to use
+the :ref:`Web interface <platform-banner>` instead
+(former files are not taken into account anymore,
+you can delete them). This will bring a more integrated experience
+than the old way. See `story #14670 <https://tuleap.net/plugins/tracker/?aid=14670>`_
+for more details.
+
+
 Tuleap 12.1
 ===========
 


### PR DESCRIPTION
MOTD files are not supported anymore.

Part of [story #14670](https://tuleap.net/plugins/tracker/?aid=14670): display a site wide banner (motd)