### PR TITLE
Announce deprecation of PermissionsOverrider

### DIFF
--- a/languages/en/administration-guide/users-management/security/permissions-overrider.rst
+++ b/languages/en/administration-guide/users-management/security/permissions-overrider.rst
@@ -1,6 +1,13 @@
 Deploy a permissions overrider
 ------------------------------
 
+.. ATTENTION::
+
+    This feature is deprecated and will be removed end of March 2021.
+
+    It's override default Tuleap security protections with code under sysadmin control, the risk of shooting themselves
+    in the feet are major and the complexity it brings in Tuleap make it even less desirable.
+
 Tuleap provides a way to have a permissions overrider to support very particular setups. The permissions overrider cannot restrict users it can only open permissions where Tuleap would normally restrict the user. In order to implement such an object, you have to create a ``/etc/tuleap/local_glue`` folder and a file ``PermissionsOverrider.php`` in it. This file must contains a class definition of ``PermissionsOverrider`` which implements the ``PermissionsOverrider_IOverridePermissions`` interface you may find in ``/usr/share/tuleap/src/common/include/PermissionsOverrider/IOverridePermissions.php``.
 
 Once you've done this, your PermissionsOverrider object will be called for each access of a user to the platform or to a particular project.

--- a/languages/en/deploy.rst
+++ b/languages/en/deploy.rst
@@ -29,6 +29,7 @@ Here is the list of what Tuleap will remove, stop or start supporting with the p
 
 End of March 2021
 '''''''''''''''''
+
 ============================= ================= ============================================================
 What                          Status            As platform administrator, what should I do ?
 ============================= ================= ============================================================

--- a/languages/en/deploy.rst
+++ b/languages/en/deploy.rst
@@ -25,67 +25,66 @@ file, the default is automatically set for you.
 Deprecations and end of support
 ===============================
 
-Here is the list of what Tuleap will remove, stop or start supporting with the
-planned time periods.
+Here is the list of what Tuleap will remove, stop or start supporting with the planned time periods.
 
-============================= ================= =============================================
-S1 2020                       Status            As platform administrator, what should I do ?
-============================= ================= =============================================
-MySQL 8                       Start of support  (Optionally switch to MySQL 8)
+End of March 2021
+'''''''''''''''''
+============================= ================= ============================================================
+What                          Status            As platform administrator, what should I do ?
+============================= ================= ============================================================
+PermissionsOverrider          Removed           :ref:`Delete the local glue <remove_permissions_overrider>`
+Subversion (SVN Core)         Removed           :ref:`Switch to SVN Plugin <svn_core_to_plugin>`
+============================= ================= ============================================================
+
+Horizon June 2021
+'''''''''''''''''
+
+============================= ================= ============================================================
+What                          Status            As platform administrator, what should I do ?
+============================= ================= ============================================================
+PHP 7.3                       End of support    Switch to PHP 7.4
+Trackers v3                   Removed           Migrate to Trackers v5
 tab file-based translations   Replaced by       Nothing
                               gettext
-============================= ================= =============================================
+============================= ================= ============================================================
 
-============================= ================= ===========================================================================================================
-S2 2020                       Status            As platform administrator, what should I do ?
-============================= ================= ===========================================================================================================
-RHEL 6                        End of support    Switch to RHEL 7
-PHP 7.4                       Start of support  (Optionally switch to PHP 7.4)
-Trackers v3                   Removed           Migrate to Trackers v5
-Subversion (SVN Core)         Removed           Switch to SVN Plugin
-Realtime server using NodeJS  Replaced          (To be announced)
-PHP 7.3                       End of support    Switch to PHP 7.4
-RHEL 8                        Start of support  (Optionally switch to RHEL 8)
+Horizon end of 2021
+'''''''''''''''''''
+
+============================= ================= ============================================================
+What                          Status            As platform administrator, what should I do ?
+============================= ================= ============================================================
 Gerrit versions < 3.1         End of support    Switch to Gerrit 3.1 or higher
-============================= ================= ===========================================================================================================
+MySQL 5.7                     End of support    Switch to MySQL 8
+============================= ================= ============================================================
 
-========= =============== =============================================
-2021      Status          As platform administrator, what should I do ?
-========= =============== =============================================
-MySQL 5.7 End of support  Switch to MySQL 8
-========= =============== =============================================
+In the future
+'''''''''''''
 
-===================== ============== =============================================
-The Future            Status         As platform administrator, what should I do ?
-===================== ============== =============================================
-SOAP API              Removed        End-users should switch to REST API
-PHP Wiki              Removed        Switch to Mediawiki
-PROFTPd               End of support End-users should use document/frs instead
-===================== ============== =============================================
+============================ ============== =============================================
+The Future                   Status         As platform administrator, what should I do ?
+============================ ============== =============================================
+SOAP API                     Removed        End-users should switch to REST API
+PHP Wiki                     Removed        Switch to Mediawiki
+PROFTPd                      End of support End-users should use document/frs instead
+Realtime server using NodeJS Replaced       (To be announced)
+============================ ============== =============================================
 
 Support already ended
 =====================
 
-==================================================== ================= ==============================================
-Q3 2019                                              Status            As platform administrator, what should I do ?
-==================================================== ================= ==============================================
-Legacy GitPHP web interface                          Removed           Nothing
-Legacy Tracker Workflows configuration web interface Removed           Nothing
-RabbitMQ (replaced by Redis)                         Replaced by Redis Uninstall RabbitMQ
-WebDAV with Windows 7 client                         End of support    End-users should switch to Cyberduck
-==================================================== ================= ==============================================
+=============================== ======== ================= ====================================================================================
+What                            When     Status            As platform administrator, what should I do ?
+=============================== ======== ================= ====================================================================================
+Internet Explorer               Q4 2020  End of support    **End-users must switch to the latest version of Firefox, Edge, Chrome or Chromium**
+RHEL 6                          Q4 2020  End of support    Switch to RHEL 7
+Codendi CLI                     Q4 2019  End of support    Use REST API
+GitShell backend for Git plugin Q4 2019  Removed           End-users should push to Gitolite repository
+Gerrit versions < 2.16          Q4 2019  End of support    Switch to Gerrit 2.16 or higher
+MySQL versions < 5.7            Q4 2019  End of support    Upgrade to MySQL 5.7 or higher
+Legacy GitPHP web interface     Q3 2019  Removed           Nothing
+Legacy Tracker Workflows UI     Q3 2019  Removed           Nothing
+RabbitMQ                        Q3 2019  Replaced by Redis Uninstall RabbitMQ
+WebDAV with Windows 7 client    Q3 2019  End of support    End-users should switch to Cyberduck
+=============================== ======== ================= ====================================================================================
 
-=============================== ================= =============================================
-Q4 2019                         Status            As platform administrator, what should I do ?
-=============================== ================= =============================================
-Codendi CLI                     End of support    Use REST API
-GitShell backend for Git plugin Removed           End-users should push to Gitolite repository
-Gerrit versions < 2.16          End of support    Switch to Gerrit 2.16 or higher
-MySQL versions < 5.7            End of support    Upgrade to MySQL 5.7 or higher
-=============================== ================= =============================================
-
-=============================== ================= ====================================================================================
-Q4 2020                         Status            As platform administrator, what should I do ?
-=============================== ================= ====================================================================================
-Internet Explorer               End of support    **End-users must switch to the latest version of Firefox, Edge, Chrome or Chromium**
-=============================== ================= ====================================================================================

--- a/languages/en/deployment-guide/12.x.rst
+++ b/languages/en/deployment-guide/12.x.rst
@@ -26,8 +26,9 @@ before support, is deprecated and should no longer be used. It still works but m
 & DNS configurations so less trouble for administrators.
 
 .. _remove_permissions_overrider:
-PermissionsOverrider deprecated
--------------------------------
+
+Permissions Overrider deprecated
+--------------------------------
 
 If you previously deployed a ``/etc/tuleap/local_glue/PermissionsOverrider.php`` this feature is now deprecated and will
 be removed end of March 2021. There is no replacement for the feature as it brings more security risk and maintenance burden
@@ -66,6 +67,7 @@ than the old way. See `story #14670 <https://tuleap.net/plugins/tracker/?aid=146
 for more details.
 
 .. _svn_core_to_plugin:
+
 Subversion Core active deprecation
 ----------------------------------
 

--- a/languages/en/deployment-guide/12.x.rst
+++ b/languages/en/deployment-guide/12.x.rst
@@ -25,6 +25,14 @@ The access via a dedicated host (like ``https://webdav.tuleap.example.com/``) th
 before support, is deprecated and should no longer be used. It still works but might be removed as it simplifies the nginx
 & DNS configurations so less trouble for administrators.
 
+.. _remove_permissions_overrider:
+PermissionsOverrider deprecated
+-------------------------------
+
+If you previously deployed a ``/etc/tuleap/local_glue/PermissionsOverrider.php`` this feature is now deprecated and will
+be removed end of March 2021. There is no replacement for the feature as it brings more security risk and maintenance burden
+than functional advantage.
+
 Tuleap 12.3
 ===========
 
@@ -57,6 +65,7 @@ you can delete them). This will bring a more integrated experience
 than the old way. See `story #14670 <https://tuleap.net/plugins/tracker/?aid=14670>`_
 for more details.
 
+.. _svn_core_to_plugin:
 Subversion Core active deprecation
 ----------------------------------
 


### PR DESCRIPTION
Take the opportunity to re-organize the deprecation tables
at it was out-dated and messy.

I removed the start of support because it's hard to commit
on dates and may let people think that we met the deadlines...