### PR TITLE
Add Step Execution as external field

### DIFF
--- a/languages/en/administration-guide/projects-management/export-import/import-format/trackers.rst
+++ b/languages/en/administration-guide/projects-management/export-import/import-format/trackers.rst
@@ -269,10 +269,27 @@ External Fields
 Since 11.14, it's possible to add external fields on import XML.
 This external fields are form elements from plugins.
 
-Test Management Step Definitions
+Test Management Step Fields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Step Definitions are external fields.
+Step Definitions and Step Executions are external fields.
+
+Step Execution structure
+#########################
+
+- Type must be ``ttmstepexec``
+- TTM must be activated in your project
+
+Here is an example of step definition field for tracker structure XML :
+
+.. sourcecode:: xml
+  :linenos:
+
+    <externalField type="ttmstepexec" ID="F431" rank="2">
+      <name><![CDATA[steps]]></name>
+      <label><![CDATA[Steps Execution]]></label>
+      <description><![CDATA[Execution of the test's steps]]></description>
+    </externalField>
 
 Step Definition structure
 #########################

--- a/languages/en/administration-guide/projects-management/export-import/import-format/trackers.rst
+++ b/languages/en/administration-guide/projects-management/export-import/import-format/trackers.rst
@@ -269,18 +269,18 @@ External Fields
 Since 11.14, it's possible to add external fields on import XML.
 This external fields are form elements from plugins.
 
-Test Management Step Fields
+Test Management step fields
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Step Definitions and Step Executions are external fields.
+Step definitions and step executions are external fields.
 
-Step Execution structure
+Step execution structure
 #########################
 
 - Type must be ``ttmstepexec``
 - TTM must be activated in your project
 
-Here is an example of step definition field for tracker structure XML :
+Here is an example of a step execution field for tracker structure XML :
 
 .. sourcecode:: xml
   :linenos:
@@ -291,13 +291,13 @@ Here is an example of step definition field for tracker structure XML :
       <description><![CDATA[Execution of the test's steps]]></description>
     </externalField>
 
-Step Definition structure
+Step definition structure
 #########################
 
 - Type must be ``ttmstepdef``
 - TTM must be activated in your project
 
-Here is an example of step definition field for tracker structure XML :
+Here is an example of a step definition field for tracker structure XML :
 
 .. sourcecode:: xml
   :linenos:


### PR DESCRIPTION
For now, only Step defintion is descibe as external field on documentation. Step execution must be add.