### PR TITLE
Remove sys_async_mails setting

### DIFF
--- a/languages/en/administration-guide/system-administration/backend-workers.rst
+++ b/languages/en/administration-guide/system-administration/backend-workers.rst
@@ -5,7 +5,7 @@ Backend workers
 
 Backend workers are used to process asynchronous tasks. Currently it is used for:
 
-* :ref:`Backend notifications<backend_notifications>`
+* Asynchronous actions like sending tracker notifications or `importing Jira issues <tracker-import-from-jira>`_
 * :ref:`Monitoring with Prometheus<admin_monitoring_with_prometheus>`
 
 It's based on a notification queue managed by Redis and a worker that will process the the queue as soon as it's pushed.
@@ -66,43 +66,3 @@ Troubleshooting
 
 You can track worker activity in ``/var/log/tuleap/worker_log`` log file (you might need to change the
 ``$sys_logger_level`` value to make if more verbose).
-
-.. _backend_notifications:
-
-Backend notifications
-=====================
-
-When you have a server with large amount of users or a mail system that is not really efficient, you may face troubles
-at artifact creation with very long creation/update timing.
-
-By profiling your page or by enabling 'debug' (``$sys_logger_level = 'debug';``) you can identify how long the notification is taking.
-
-Look at ``[Tuleap\Tracker\Artifact\Changeset\Notification\Notifier]`` string in ``codendi_syslog`` and measure how long it takes
-between ``Start notification`` and ``End notification`` marker. You can save this amount of time to your end users by
-switching to backend based notifications.
-
-Configure Tuleap
-----------------
-
-In ``local.inc`` you should add ``$sys_async_emails`` variable. It can take following values:
-
-* ``''``: equivalent to not defining the variable at all: disable backend notifications, the notification will be done inline. Useful to disable the feature if it doesn't work.
-* ``'all'``: activate the feature for all projects.
-* ``'X,Y,Z'``: activate the feature for projects X, Y and Z (project ids, integers)
-
-.. note::
-
-  ``$sys_async_emails`` is independent of ``$sys_nb_backend_workers`` configuration.
-  This means that even if ``$sys_nb_backend_workers`` is not set (or set to ``0``),
-  then backend notifications will still be available.
-
-After having set the variable to at least 1 project, the backend worker (``/usr/share/tuleap/src/utils/worker.php``) will automatically be started by Tuleap
-and will process jobs and send emails.
-
-Troubleshooting
----------------
-
-The front end will log useful information in ``codendi_syslog`` with the key ``Notification``.
-
-We also added a double check in ``SYSTEM_CHECK`` system event to ensure there is no pending notifications that last forever.
-If such a situation occurs, the SystemEvent will be marked as Warning, be sure to monitor that.

--- a/languages/en/deployment-guide/12.x.rst
+++ b/languages/en/deployment-guide/12.x.rst
@@ -8,6 +8,12 @@ Tuleap 12.5
 
   Tuleap 12.5 is currently under development.
 
+Settings ``sys_async_emails`` is no more used
+---------------------------------------------
+
+Tracker notifications are now always sent asynchronously as soon as Tuleap detects :ref:`backend workers<admin_howto_backend_worker>`.
+You can safely remove this setting from your ``/etc/tuleap/conf/local.inc`` file.
+
 Tuleap 12.4
 ===========
 


### PR DESCRIPTION
Part of [request #19219](https://tuleap.net/plugins/tracker/?aid=19219): Creating a new tracker from a Jira import might not be available even when the instance can do background processing