### PR TITLE
Calling /usr/share/tuleap/tools/utils/php73/run.php is no more useful

### DIFF
--- a/languages/en/installation-guide/install-plugins.rst
+++ b/languages/en/installation-guide/install-plugins.rst
@@ -20,7 +20,7 @@ is the name of the package of the plugin you want to install):
 
     # On RHEL/CentOS 7
     yum install tuleap-plugin-awesomestuff
-    /usr/share/tuleap/tools/utils/php73/run.php --module=nginx
+    tuleap-cfg site-deploy
     systemctl reload nginx
     systemctl restart tuleap-php-fpm
 

--- a/languages/en/installation-guide/update.rst
+++ b/languages/en/installation-guide/update.rst
@@ -40,9 +40,6 @@ On RHEL/CentOS 7, run as root:
     # Apply data upgrades
     /usr/lib/forgeupgrade/bin/forgeupgrade --config=/etc/tuleap/forgeupgrade/config.ini update
 
-    # Re-generate nginx configuration
-    /usr/share/tuleap/tools/utils/php73/run.php --module=nginx
-
     # Deploy site configurations
     tuleap-cfg site-deploy
 


### PR DESCRIPTION
Part of [request #18496](https://tuleap.net/plugins/tracker/?aid=18496): Move nginx & apache configuration deployment to tuleap-cfg site-deploy