### PR TITLE
Disable all write permissions in GHA workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,7 @@
 name: CI
 
+permissions: read-all
+
 on:
   push:
     branches:


### PR DESCRIPTION
This limit the impacts if an action is compromised somehow.