### PR TITLE
Fix CVE-2021-23368 of postcss dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -202,9 +202,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.1.22",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-            "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -238,13 +238,13 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.2.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+            "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
             "dev": true,
             "dependencies": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.22",
+                "nanoid": "^3.1.23",
                 "source-map": "^0.6.1"
             },
             "engines": {
@@ -493,9 +493,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.1.22",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-            "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+            "version": "3.1.23",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+            "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
             "dev": true
         },
         "normalize-path": {
@@ -517,13 +517,13 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.2.9",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-            "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+            "version": "8.2.15",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+            "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",
-                "nanoid": "^3.1.22",
+                "nanoid": "^3.1.23",
                 "source-map": "^0.6.1"
             }
         },


### PR DESCRIPTION
No security impact on the build as we do not use PostCSS.