### PR TITLE
Use PHP 7.4 typed properties in code examples

### DIFF
--- a/languages/en/developer-guide/back-end/events.rst
+++ b/languages/en/developer-guide/back-end/events.rst
@@ -190,12 +190,9 @@ The class ``GetPublicAreas`` looks like the following:
             /**
              * @var string[]
              */
-            private $areas;
+            private array $areas;
 
-            /**
-             * @var Project
-             */
-            private $project;
+            private Project $project;
 
             public function __construct(Project $project)
             {

--- a/languages/en/developer-guide/front-end/mustache.rst
+++ b/languages/en/developer-guide/front-end/mustache.rst
@@ -26,8 +26,7 @@ Example of Presenter
 
     class Presenter
     {
-        /** @var string */
-        public $my_title;
+        public string $my_title;
 
         public function __construct()
         {
@@ -65,10 +64,7 @@ If you need to put light formatting in you localised string, then you should esc
 
     class Presenter
     {
-        /**
-         * @var string
-         */
-        public $purified_description;
+        public string $purified_description;
 
         public function __construct()
         {
@@ -138,10 +134,7 @@ Presenter.php:
 
     class Presenter
     {
-        /**
-         * @var CSRFSynchronizerToken
-         */
-         public $csrf_token;
+         public CSRFSynchronizerToken $csrf_token;
 
         public function __construct(CSRFSynchronizerToken $csrf_token)
         {


### PR DESCRIPTION
Part of [request #20938](https://tuleap.net/plugins/tracker/?aid=20938): Add support of PHP 7.4