### PR TITLE
Build docs.tuleap.org using the same tools than developers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,10 @@
-{ pkgs ? import (fetchTarball { 
-    url = "https://github.com/NixOS/nixpkgs/archive/3bc8e5cd23b84b2e149e7aaad57117da16a19e6f.tar.gz";
-    sha256 = "16h0a45ncrjf3hcpqbkflmzfijgq2skkick6g2pr9ksy1rg0h6rb";
-} ) {} }:
-
-pkgs.stdenv.mkDerivation {
-    name = "tuleap-documentation-en-build";
-    buildInputs = [
-        pkgs.gnumake
-        pkgs.gnugrep
-        pkgs.gnused
-        pkgs.gawk
-        pkgs.python39Packages.virtualenv
-        pkgs.nodejs-slim-14_x
-        pkgs.nodePackages.npm
-    ];
-}
+{ pkgs ? (import ./pinned-nixpkgs.nix) {} }:
+[
+  pkgs.gnumake
+  pkgs.gnugrep
+  pkgs.gnused
+  pkgs.gawk
+  pkgs.python39Packages.virtualenv
+  pkgs.nodejs-slim-14_x
+  pkgs.nodePackages.npm
+]

--- a/docs.tuleap.org/Dockerfile
+++ b/docs.tuleap.org/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine:3.13.5 AS builder
-
-RUN apk add --no-cache git make python3 py-virtualenv nodejs npm
+FROM nixos/nix:2.3.11 AS builder
 
 RUN addgroup -S builder && adduser -S -G builder builder
 
-USER builder
-
 COPY --chown=builder:builder . /home/builder/tuleap-documentation
+
+RUN nix-env --install -f /home/builder/tuleap-documentation/default.nix
+
+USER builder
 
 WORKDIR /home/builder/tuleap-documentation
 
@@ -16,7 +16,7 @@ RUN npm ci && npm run build && \
     pip install -r requirements.txt && \
     make SPHINXOPTS="-D html_theme=tuleap_org" html
 
-FROM nginx:alpine
+FROM nginx:1.21.0-alpine
 
 COPY docs.tuleap.org/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /home/builder/tuleap-documentation/_build/html/en/ /usr/share/nginx/html

--- a/pinned-nixpkgs.nix
+++ b/pinned-nixpkgs.nix
@@ -1,0 +1,8 @@
+{}:
+
+let
+  pinnedNixpkgs = import (fetchTarball { 
+    url = "https://github.com/NixOS/nixpkgs/archive/3bc8e5cd23b84b2e149e7aaad57117da16a19e6f.tar.gz";
+    sha256 = "16h0a45ncrjf3hcpqbkflmzfijgq2skkick6g2pr9ksy1rg0h6rb";
+  } ) {};
+in pinnedNixpkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? (import ./pinned-nixpkgs.nix) {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    (import ./default.nix { inherit pkgs; })
+  ];
+}


### PR DESCRIPTION
This makes sure the build is consistent and avoid surprises between different tool versions. Also, this way there is only one tool list to maintain.