### PR TITLE
Fix the apparence of the download links on the docs.tuleap.org theme

### DIFF
--- a/languages/en/_themes/tuleap_org/style/backbone/_basic-elements.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_basic-elements.scss
@@ -143,6 +143,24 @@ code {
     line-height: 24px;
 }
 
+// Download link
+code.download {
+    background: inherit;
+    padding: inherit;
+    font-weight: normal;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    border: inherit;
+    white-space: inherit;
+
+    > span:first-child::before {
+        @extend .fa;
+        @extend .fa-download;
+        margin-right: 4px;
+    }
+}
+
 strong {
     font-weight: 600;
 }


### PR DESCRIPTION
The download links are shown as inlined code, this contribution makes them render as standard links with a download icon first (like it is the case on the RTD theme).