### PR TITLE
Fix the build of the linkcheck Docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,3 +37,11 @@ jobs:
         uses: actions/checkout@v2.4.0
       - name: Build image
         run: docker build -f docs.tuleap.org/Dockerfile -t test-build .
+  build_docker_image_linkcheck:
+    name: Check build of the Docker image used to run linkcheck
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+      - name: Build image
+        run: DOCKER_BUILDKIT=1 docker build -f linkcheck-docker.nix -t test-build-linkcheck .

--- a/Dockerfile-linkcheck
+++ b/Dockerfile-linkcheck
@@ -1,5 +1,0 @@
-FROM nixos/nix:2.5.1
-
-COPY *.nix ./
-
-RUN nix-env --install -f ./default.nix

--- a/Jenkinsfile-linkcheck
+++ b/Jenkinsfile-linkcheck
@@ -2,7 +2,7 @@ pipeline {
     agent {
         dockerfile {
             label 'docker'
-            filename 'Dockerfile-linkcheck'
+            filename 'linkcheck-docker.nix'
         }
     }
 

--- a/linkcheck-docker.nix
+++ b/linkcheck-docker.nix
@@ -1,0 +1,9 @@
+# syntax = ghcr.io/akihirosuda/buildkit-nix:v0.0.1@sha256:97205438b67bc0b3a4ae5e9c38f610723bd81102bcbf215ca833cf68e99978e0
+
+{ pkgs ? (import ./pinned-nixpkgs.nix) {}, baseContents ? (import ./default.nix { inherit pkgs; } ) }:
+
+pkgs.dockerTools.buildImage {
+  name = "tuleap-documentation-en-linkcheck";
+  extraCommands = "mkdir -m 0777 tmp";
+  contents = baseContents ++ [ pkgs.bash pkgs.mktemp pkgs.coreutils ];
+}


### PR DESCRIPTION
We now use [buildkit-nix](https://github.com/AkihiroSuda/buildkit-nix/) to directly build the image