### PR TITLE
Add dev tools to the Nix store when building the Gitpod image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -20,11 +20,7 @@ RUN touch .bash_profile \
 
 RUN echo '. /home/gitpod/.nix-profile/etc/profile.d/nix.sh' >> /home/gitpod/.bashrc
 
-# Install git
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
-  && nix-env -i git git-lfs
+COPY default.nix /tmp/
+COPY pinned-nixpkgs.nix /tmp/
 
-# Install direnv
-RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh \
-  && nix-env -i direnv \
-  && direnv hook bash >> /home/gitpod/.bashrc
+RUN . /home/gitpod/.nix-profile/etc/profile.d/nix.sh && nix-build --no-out-link /tmp/default.nix

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,6 @@ image:
   file: .gitpod.Dockerfile
 tasks:
   - init: >
-      mkdir -p /home/gitpod/.config/nix &&
-      echo 'sandbox = false' >> /home/gitpod/.config/nix/nix.conf &&
       nix-shell --command "virtualenv venv && source venv/bin/activate && pip install -r requirements.txt -r requirements-dev.txt && npm ci && npm run build && make SPHINXOPTS=\"-D html_theme=tuleap_org\" watch-html"
 ports:
   - port: 5000


### PR DESCRIPTION
This way we do not need to pull them each time we open the workspace but only once when we build the image (note that we could pre-build them).

Also removed the tools that were downloaded from a unpinned nixpkgs.