### PR TITLE
Add python extension

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,3 +11,4 @@ vscode:
     - bbenoist.Nix
     - lextudio.restructuredtext
     - trond-snekvik.simple-rst
+    - ms-python.python

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}


### PR DESCRIPTION
This is not strictly required but at this time it's an automatic workaround
for the typing issues (shortcuts, enter, etc) that are not well supported
with restructured text & gitpod