### PR TITLE
Document is now part of Tuleap Community Edition

### DIFF
--- a/languages/en/user-guide/documents-and-files/document.rst
+++ b/languages/en/user-guide/documents-and-files/document.rst
@@ -3,12 +3,6 @@
 Document Manager modern interface (2019)
 ========================================
 
-.. attention::
-
-  This module is part of :ref:`Tuleap Enterprise <tuleap-enterprise>`. It might
-  not be available on your installation of Tuleap. You will need to install ``tuleap-plugin-document`` rpm and activate
-  ``document`` plugin as site administrator.
-
 The new interface of document manager provides a modern way to interact with document manager.
 This new interface has been designed for most common actions.
 

--- a/languages/en/user-guide/tuleap-entreprise.rst
+++ b/languages/en/user-guide/tuleap-entreprise.rst
@@ -25,11 +25,6 @@ Project management
 * :ref:`Timetracking <timetracking>`: Provide an easy way to track your time
 * :ref:`Velocity <plugin_velocity>`: Display velocity chart in the Agile Dashboard
 
-File deliveries and documentation
----------------------------------
-
-* :ref:`Document <plugin_document>`: Modern document management
-
 Authentication and permissions
 ------------------------------
 


### PR DESCRIPTION
We should remove the warning at the top of the dedicated documentation
and remove it from the list of Tuleap Enterprise plugins.

Part of [story #26808: have document part of Community Edition][0]

[0]: https://tuleap.net/plugins/tracker/?aid=26808