### PR TITLE
Add back context in search results when using the tuleap.org theme

### DIFF
--- a/languages/en/_themes/tuleap_org/static/documentation_options.js_t
+++ b/languages/en/_themes/tuleap_org/static/documentation_options.js_t
@@ -8,5 +8,6 @@ var DOCUMENTATION_OPTIONS = {
     LINK_SUFFIX: '{{ link_suffix }}',
     HAS_SOURCE: {{ has_source|lower }},
     SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}',
-    NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}}
+    NAVIGATION_WITH_KEYS: {{ 'true' if theme_navigation_with_keys|tobool else 'false'}},
+    SHOW_SEARCH_SUMMARY: true
 };

--- a/languages/en/administration-guide/users-management/security/dynamic-credentials.rst
+++ b/languages/en/administration-guide/users-management/security/dynamic-credentials.rst
@@ -34,7 +34,7 @@ on your Tuleap instance, see :ref:`install-plugins` to learn how to do that.
 
 On your Vault instance, you must install the ``vault-tuleap-plugin`` and mount
 the secret engine, refer to the
-`Vault documentation <https://www.vaultproject.io/docs/plugin>`_ to
+`Vault documentation <https://www.vaultproject.io/docs/plugins/plugin-management>`_ to
 learn how to do that. A compiled version of the ``vault-tuleap-plugin`` can be
 found `here <https://ci.tuleap.org/jenkins/job/vault-tuleap-plugin-build/>`_.
 This document assumes the Tuleap secrets engine is enabled at the ``tuleap``


### PR DESCRIPTION
The context of search results is displayed (or not) depending on a conf setting in recent versions of Sphinx.