### PR TITLE
Prevent anchor section links to go under the header on tuleap.org theme

### DIFF
--- a/languages/en/_themes/tuleap_org/style/backbone/_header.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_header.scss
@@ -380,3 +380,7 @@ span.header-menu-item {
     line-height: normal;
     text-transform: uppercase;
 }
+
+section {
+    scroll-margin-top: $header-pinned-height;
+}


### PR DESCRIPTION
It avoids the annoyance of opening a link and not seeing what the section is.

Note that the `scroll-margin-top` is always set even when the `.pinned` class is not set on the `body`. The `.pinned` class is set via a JS script so the browser is likely to have already scroll to the section before the class is set (and so the section would end up under the header).