### PR TITLE
Update minimal Jenkins requirement

### DIFF
--- a/languages/en/user-guide/ci.rst
+++ b/languages/en/user-guide/ci.rst
@@ -16,7 +16,7 @@ Jenkins Configuration
 
 .. attention::
    
-    The currently minimal Jenkins version is **2.249.3**
+    The currently minimal Jenkins version is **2.289.3**
 
     The currently minimal Tuleap version should be **12.11**
 


### PR DESCRIPTION
`tuleap-api-plugin` for Jenkins is about to be updated to version `2.289.3` of Jenkins.