### PR TITLE
doc: Add documentation for email relay

### DIFF
--- a/languages/en/administration-guide/application-management/plugins/trackers.rst
+++ b/languages/en/administration-guide/application-management/plugins/trackers.rst
@@ -31,6 +31,7 @@ email address (forge__artifact+id@... to update an artifact and forge__tracker+i
     If you still want to enable this option, it is highly recommended to use a
     dedicated domain name (see ``sys_default_mail_domain`` in your ``local.inc`` file).
 
+    This option will only work when Tuleap is configured to use :ref:`the self hosted email configuration <emailrelay>`
 
 Once activated by site admin, each tracker admin that wants this feature to be enabled needs to manually
 activate the feature in tracker "General Settings" screen. The tracker must respect some constraints:

--- a/languages/en/administration-guide/system-administration/email-relay.rst
+++ b/languages/en/administration-guide/system-administration/email-relay.rst
@@ -6,25 +6,25 @@ Email relay
 Starting Tuleap 13.12, the email sent can be configured with two options:
 
 * Using the self hosted email configuration (``sendmail``)
-* Using an smtp relay (``smtp``)
+* Using an SMTP relay (``smtp``)
 
 The self hosted email configuration (``sendmail``) is the one used by default and is the configration already used by Tuleap.
 You can find :ref:`the local postfix configuration here. <services_postfix>`
 
-You can also setup Tuleap to use an external Smtp (``smtp``) server. To do this, you have to configure two system variables:
+You can also setup Tuleap to use an external SMTP (``smtp``) server. To do this, you have to configure two system variables:
 
 * ``email_transport``
 * ``email_relayhost``
 
 ``email_transport`` must be set to ``smtp``, and ``email_relayhost`` must contains the URL of the relay and the port separated by ``:``.
 
-.. warning:: When configured to use an Smtp server, some features will not work anymore. These features are:
+.. warning:: When configured to use an SMTP server, some features will not work anymore. These features are:
 
     * :ref:`Tracker mail gateway <admin_tracker_reply_by_email>`
     * ForumML
 
     Some notifications from legacy services will still use the self hosted Tuleap email to work:
 
-    * Phpwiki notifications
+    * PHPWiki notifications
     * CVS notifications
     * SVN core notifications

--- a/languages/en/administration-guide/system-administration/email-relay.rst
+++ b/languages/en/administration-guide/system-administration/email-relay.rst
@@ -1,0 +1,30 @@
+..  _emailrelay:
+
+Email relay
+###########
+
+Starting Tuleap 13.12, the email sent can be configured with two options:
+
+* Using the self hosted email configuration (``sendmail``)
+* Using an smtp relay (``smtp``)
+
+The self hosted email configuration (``sendmail``) is the one used by default and is the configration already used by Tuleap.
+You can find :ref:`the local postfix configuration here. <services_postfix>`
+
+You can also setup Tuleap to use an external Smtp (``smtp``) server. To do this, you have to configure two system variables:
+
+* ``email_transport``
+* ``email_relayhost``
+
+``email_transport`` must be set to ``smtp``, and ``email_relayhost`` must contains the URL of the relay and the port separated by ``:``.
+
+.. warning:: When configured to use an Smtp server, some features will not work anymore. These features are:
+
+    * :ref:`Tracker mail gateway <admin_tracker_reply_by_email>`
+    * ForumML
+
+    Some notifications from legacy services will still use the self hosted Tuleap email to work:
+
+    * Phpwiki notifications
+    * CVS notifications
+    * SVN core notifications

--- a/languages/en/administration-guide/system-administration/services.rst
+++ b/languages/en/administration-guide/system-administration/services.rst
@@ -305,6 +305,8 @@ service as telnet comes standard with the Windows operating system.
 However we highly recommend not to enable telnet for security reasons
 and instruct your Windows users to install an SSH client instead.
 
+..  _services_postfix:
+
 Postfix
 -------
 

--- a/languages/en/installation-guide/docker-image.rst
+++ b/languages/en/installation-guide/docker-image.rst
@@ -57,9 +57,6 @@ Deploy a test environment with docker-compose
     not a recommended setup unless you perfectly understand how to operate (run, backup, restore, troubleshoot) them under
     docker constraints.
 
-    Please note that not all plugins can be used with this configuration setting (:ref:`email_relay<emailrelay>`) and you might need to 
-    customize the image to fit your needs.
-
 In a directory named ``tuleap-community-edition`` (be careful, with docker-compose, directory name matters) create a
 ``.env`` file that defines two variables:
 
@@ -396,6 +393,11 @@ Email
 
 * ``TULEAP_EMAIL_TRANSPORT``: email transport (sendmail by default). (**since 13.12**).
 * ``TULEAP_EMAIL_RELAYHOST``: email relay host (none by default).
+
+.. warning::
+
+    Please note that not all plugins can be used with this configuration setting (:ref:`email_relay<emailrelay>`) and you might need to 
+    customize the image to fit your needs.
 
 TLS Certificates
 ````````````````

--- a/languages/en/installation-guide/docker-image.rst
+++ b/languages/en/installation-guide/docker-image.rst
@@ -57,6 +57,9 @@ Deploy a test environment with docker-compose
     not a recommended setup unless you perfectly understand how to operate (run, backup, restore, troubleshoot) them under
     docker constraints.
 
+    Please note that not all plugins can be used with this configuration setting (:ref:`email_relay<emailrelay>`) and you might need to 
+    customize the image to fit your needs.
+
 In a directory named ``tuleap-community-edition`` (be careful, with docker-compose, directory name matters) create a
 ``.env`` file that defines two variables:
 
@@ -107,6 +110,7 @@ Then create a ``docker-compose.yml`` file with following content:
           - DB_ADMIN_PASSWORD=${MYSQL_ROOT_PASSWORD}
           - TULEAP_FPM_SESSION_MODE=redis
           - TULEAP_REDIS_SERVER=redis
+          - TULEAP_EMAIL_TRANSPORT=smtp
           - TULEAP_EMAIL_RELAYHOST=mailhog:1025
 
       # This is for test purpose only. It's not advised to run a production database as a docker container
@@ -215,6 +219,7 @@ Then you can init docker image in command line:
         -e TULEAP_FPM_SESSION_MODE=redis \
         -e TULEAP_REDIS_SERVER=redis \
         -e TULEAP_REDIS_PASSWORD=${REDIS_PASSWORD} \
+        -e TULEAP_EMAIL_TRANSPORT=smtp \
         -e TULEAP_EMAIL_RELAYHOST=your-smtp.example.com:2025 \
         -v /srv/path/to/data:/data
         tuleap/tuleap-community-edition
@@ -231,6 +236,7 @@ For future runs you don't need to pass all the environments:
         --hostname tuleap-ce.example.com \
         -e TULEAP_FPM_SESSION_MODE=redis \
         -e TULEAP_REDIS_SERVER=redis \
+        -e TULEAP_EMAIL_TRANSPORT=smtp \
         -e TULEAP_EMAIL_RELAYHOST=your-smtp.example.com:2025 \
         -v /srv/path/to/data:/data
         tuleap/tuleap-community-edition
@@ -388,6 +394,7 @@ Redis
 Email
 #####
 
+* ``TULEAP_EMAIL_TRANSPORT``: email transport (sendmail by default). (**since 13.12**).
 * ``TULEAP_EMAIL_RELAYHOST``: email relay host (none by default).
 
 TLS Certificates

--- a/languages/en/installation-guide/full-installation.rst
+++ b/languages/en/installation-guide/full-installation.rst
@@ -168,7 +168,7 @@ Do not forget to restart nginx with ``systemctl restart nginx`` after a modifica
 
 Mail configuration
 ------------------
-Tuleap interacts with Postfix to process mails. The following lines should be uncommented/modified in
+Tuleap interacts with Postfix by default to process mails. The following lines should be uncommented/modified in
 the main Postfix configuration file generally located in /etc/postfix/main.cf:
 
 ::


### PR DESCRIPTION
This is part of story #27133 send mail without postfix

Add a new section in System administration to explain how to configure
the email relay.

Some modifications are done in other part of the documentation to
reflects this new configuration.