### PR TITLE
Add a CI steps building the doc using the Python provided by the Nix environment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,6 +29,15 @@ jobs:
           pip install -r requirements.txt
       - name: Build
         run: make SPHINXOPTS='-W' html
+  build_warning_nix:
+    name: Build with warnings as errors using the environment provided by Nix
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
+      - name: Build
+        run: nix-shell --pure --run 'make SPHINXOPTS='-W' html'
   build_docker_image_theme_tuleap_org:
     name: Check build of the Docker image with the tuleap.org theme (docs.tuleap.org)
     runs-on: ubuntu-22.04


### PR DESCRIPTION

The other builds done with a Python provided by the GHA actions/setup-python will be removed at the same time than the requirements.txt/requirements-dev.txt.