### PR TITLE
Adding upgrade instruction for Meilisearch 0.30.0

### DIFF
--- a/languages/en/administration-guide/application-management/plugins/full-text-search.rst
+++ b/languages/en/administration-guide/application-management/plugins/full-text-search.rst
@@ -56,6 +56,8 @@ Meilisearch backend rely on a Meilisearch server. Tuleap ships with a local serv
 server (aka local server). It's also possible to use a remote instance either hosted by `Meilisearch <https://www.meilisearch.com/>`_ 
 or inside your own infrastructure (for scalability or separation of concerns reasons).
 
+.. _fts-local-meilisearch:
+
 Local server
 ^^^^^^^^^^^^
 

--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -8,7 +8,21 @@ Tuleap 14.3
 
   Tuleap 14.3 is currently under development.
 
-Nothing to mention.
+
+Upgrade of the local Meilisearch instance from 0.29.0 to 0.30.0
+---------------------------------------------------------------
+
+This is only a concern for you if you have deployed a :ref:`local Meilisearch instance <fts-local-meilisearch>`.
+
+This upgrade requires to "update" the Meilisearch database to the new version.
+
+In order to do that, drop all the existing data and then ask Tuleap to re-index everything after you have upgraded the packages:
+
+.. sourcecode:: shell
+
+    rm -rf /var/lib/tuleap/fts_meilisearch_server/data.ms/
+    tuleap full-text-search:identify-all-items-to-index
+    tuleap full-text-search:index-all-pending-items
 
 Tuleap 14.2
 ===========


### PR DESCRIPTION
Closes request #29633: Meilisearch: 0.29.2 -> 0.30.0