### PR TITLE
More complete install by default

### DIFF
--- a/languages/en/installation-guide/full-installation.rst
+++ b/languages/en/installation-guide/full-installation.rst
@@ -96,12 +96,21 @@ on the `Remi's RPM repositories Repository Configuration page <https://blog.remi
     yum install -y \
       rh-mysql80-mysql-server \
       tuleap \
-      tuleap-plugin-agiledashboard \
-      tuleap-plugin-graphontrackers \
       tuleap-theme-burningparrot \
       tuleap-theme-flamingparrot \
+      tuleap-plugin-agiledashboard \
+      tuleap-plugin-graphontrackers \
       tuleap-plugin-git \
-      tuleap-plugin-pullrequest
+      tuleap-plugin-hudson-git \
+      tuleap-plugin-pullrequest \
+      tuleap-plugin-gitlfs \
+      tuleap-plugin-document \
+      tuleap-plugin-onlyoffice \
+      tuleap-plugin-embed \
+      tuleap-plugin-gitlab \
+      tuleap-plugin-securitytxt \
+      tuleap-plugin-openidconnectclient \
+      tuleap-plugin-ldap
 
 You can install more plugins, see the whole list on the :ref:`plugin list page <install-plugins>`. However you don't have
 to install all of them now. Start small and add them on the go.

--- a/languages/en/installation-guide/full-installation.rst
+++ b/languages/en/installation-guide/full-installation.rst
@@ -108,7 +108,6 @@ on the `Remi's RPM repositories Repository Configuration page <https://blog.remi
       tuleap-plugin-onlyoffice \
       tuleap-plugin-embed \
       tuleap-plugin-gitlab \
-      tuleap-plugin-securitytxt \
       tuleap-plugin-openidconnectclient \
       tuleap-plugin-ldap
 


### PR DESCRIPTION
People usually copy/paste things when they install. It makes more sense to list the more commonly used packages
instead to have a restricted list of packages.