### PR TITLE
Drop last reference of `Project Website`

### DIFF
--- a/languages/en/administration-guide/projects-management.rst
+++ b/languages/en/administration-guide/projects-management.rst
@@ -8,4 +8,3 @@ Projects management
    projects-management/projects-settings
    projects-management/projects-templates
    projects-management/project-export-import
-   projects-management/project-website

--- a/languages/en/administration-guide/projects-management/project-website.rst
+++ b/languages/en/administration-guide/projects-management/project-website.rst
@@ -1,7 +1,0 @@
-Project Web Site
-~~~~~~~~~~~~~~~~
-
-.. danger:: Enabling this feature **has major security consequences**, as such the feature is disabled by default.
-   It is strongly advised to leave it disabled.
-
-When a project is registered on Tuleap a new web site is created for that project. A default home page is installed for that project from the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file. You may want to create your own custom file for your own Tuleap site. To do so, copy the ``/usr/share/tuleap/site-content/en_US/others/default_page.php`` file in the ``/etc/tuleap/site-content/en_US/others/`` directory if not already there. Then, edit the custom file and customize it to your liking


### PR DESCRIPTION
Deploying this is basically not really possible anymore. Keeping the information in the documentation is more confusing than anything else.