### PR TITLE
Add info about the 1.0.0 upgrade of the local Meilisearch server

### DIFF
--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -8,6 +8,22 @@ Tuleap 14.6
 
   Tuleap 14.6 is currently under development.
 
+Upgrade of the local Meilisearch instance from 0.35.0 to 1.0.0
+---------------------------------------------------------------
+
+This is only a concern for you if you have deployed a :ref:`local Meilisearch instance <fts-local-meilisearch>`.
+
+This upgrade requires to "update" the Meilisearch database to the `new 1.0.0 version <https://blog.meilisearch.com/v1-enterprise-ready-stable/>`_ 🎉.
+
+In order to do that, drop all the existing data and then ask Tuleap to re-index everything after you have upgraded the packages:
+
+.. sourcecode:: shell
+
+    rm -rf /var/lib/tuleap/fts_meilisearch_server/data.ms/
+    tuleap full-text-search:identify-all-items-to-index
+    tuleap full-text-search:index-all-pending-items
+
+
 Removal of remaining dependencies to PHP 8.0 packages
 -----------------------------------------------------
 


### PR DESCRIPTION
Part of [request #30751](https://tuleap.net/plugins/tracker/?aid=30751): Meilisearch: 0.30.5 -> 1.0.0