### PR TITLE
Complement user registration flowchart for project invitation

### DIFF
--- a/languages/en/developer-guide/back-end/flowcharts.rst
+++ b/languages/en/developer-guide/back-end/flowcharts.rst
@@ -11,7 +11,7 @@ See dedicated flowchart in Security: :ref:`user-authentication-flowchart`
 User registration
 -----------------
 
-*Last revision of the graph: January 20th, 2022*
+*Last revision of the graph: February 8th, 2023*
 
 .. mermaid::
 
@@ -26,28 +26,35 @@ User registration
 
         create --> created?{Account <br>created?}
         created? -->|no| Errors!:::danger
-        created? -->|yes| oidc(OIDC link registering account)
+        created? -->|yes| oidc[OIDC link<br> registering account]
 
         oidc --> admin?{User created <br> by site admin?}
         email? -->|no| admin_creation[/The user account was created.<br>Please note the login and pwd/]:::success
         admin? -->|yes| email?{Should send <br>an email?}
 
         admin? -->|no| no_approval?{sys_user_approval<br>=0?}
-        email? -->|yes| email(Send email to user with login and pwd)
+        email? -->|yes| email[Send email to user<br> with login and pwd]
 
         email --> admin_creation
 
         no_approval? -->|no| approval![/Wait for approval/]:::success
         no_approval? -->|yes| invitation?{User invited<br>with token?}
 
-        invitation? --> |no| confirmation(Send confirmation email)
-        invitation? --> |yes| my[Log user<br>Redirect to /my/ page]
+        invitation? --> |no| confirmation[Send<br> confirmation email]
+        invitation? --> |yes| log[Log user]
 
-        my --> welcome[/Welcome modal<br>on /my/ page/]:::success
+        log --> in_project?{Invited in<br> project?}
+
+        in_project? -->|no| my[Redirect to<br> /my/ page]
+        in_project? -->|yes| project[Redirect to<br> project dashboard]
+
+        project --> welcome_project[/Welcome modal<br>on project dashboard/]:::success
+
+        my --> welcome_my[/Welcome modal<br>on /my/ page/]:::success
 
         confirmation --> delivery?{Mail accepted <br>for delivery?}
         delivery? -->|no| nodelivery[/Action required<br>The confirmation email<br>couldn't be sent./]:::danger
-        delivery? -->|yes| sent![/Confirmation link sent/]:::success
+        delivery? -->|yes| sent![/Confirmation link<br> sent/]:::success
 
         classDef success fill:#f4f8e9,stroke:#6abf1d,color:#137900
         classDef danger fill:#ffe5e5,stroke:#f02727,color:#b70d0d


### PR DESCRIPTION
When users are invited into a project, they are not redirected to my, they are redirected to project dashboard.

Part of [story #30021][0]: Invite buddies to my Tuleap project

[0]: https://tuleap.net/plugins/tracker/?aid=30021