### PR TITLE
Do not load mermaid script from an external server

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,25 +10,6 @@ on:
   pull_request:
 
 jobs:
-  build_warning:
-    name: Build with warnings as errors
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: [3.8, 3.9]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Build
-        run: make SPHINXOPTS='-W' html
   build_warning_nix:
     name: Build with warnings as errors using the environment provided by Nix
     runs-on: ubuntu-22.04

--- a/build-support/build-tools.nix
+++ b/build-support/build-tools.nix
@@ -4,6 +4,7 @@
   pkgs.gnugrep
   pkgs.gnused
   pkgs.gawk
+  pkgs.nodePackages.mermaid-cli
   (pkgs.poetry2nix.mkPoetryEnv {
     projectDir = ../.;
     # Some overrides are needed because some packages does not define their build deps correctly

--- a/languages/en/conf.py
+++ b/languages/en/conf.py
@@ -293,3 +293,9 @@ rediraffe_redirects = {
 
 # 404 page
 notfound_urls_prefix = ''
+
+# Mermaid extension
+# No external script must be loaded
+mermaid_version = ''
+mermaid_init_js = ''
+mermaid_output_format = 'svg'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,0 @@
-sphinx-autobuild==2021.3.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-Sphinx==5.2.3
-sphinx_rtd_theme==1.0.0
-sphinxext-rediraffe==0.2.7
-sphinx-notfound-page==0.8.3
-sphinxcontrib-mermaid==0.7.1


### PR DESCRIPTION
It gets blocked by our CSPs anyway and outside the security concern of loading a non pinned script this is unlikely to be legal under European laws.

Took the easiest way here and the graphs are now generated during the build. It also avoid loading 800KB+ of JS on every page.