### PR TITLE
Disable Chrome/Puppeteer sandbox when building the diagrams

### DIFF
--- a/build-support/puppeteer-config.json
+++ b/build-support/puppeteer-config.json
@@ -1,0 +1,3 @@
+{
+    "args": ["--no-sandbox"]
+}

--- a/languages/en/conf.py
+++ b/languages/en/conf.py
@@ -299,3 +299,4 @@ notfound_urls_prefix = ''
 mermaid_version = ''
 mermaid_init_js = ''
 mermaid_output_format = 'svg'
+mermaid_params = ['-p' 'build-support/puppeteer-config.json']


### PR DESCRIPTION
It avoids the annoyances when building the Docker image (or in the container). We could fix it properly but it is not untrusted content anyway.

The diagrams on https://docs.tuleap.org will be visible again.