### PR TITLE
Tuleap 14.6 is released

### DIFF
--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -1,12 +1,15 @@
 Tuleap 14.x
 ###########
 
-Tuleap 14.6
+Tuleap 14.7
 ===========
 
 .. NOTE::
 
-  Tuleap 14.6 is currently under development.
+  Tuleap 14.7 is currently under development.
+
+Tuleap 14.6
+===========
 
 Upgrade of the local Meilisearch instance from 0.35.0 to 1.0.0
 ---------------------------------------------------------------


### PR DESCRIPTION
Deployment guide must remove "under development" section for 14.6