### PR TITLE
Update Jenkins minimal version

### DIFF
--- a/languages/en/user-guide/ci.rst
+++ b/languages/en/user-guide/ci.rst
@@ -16,7 +16,7 @@ Jenkins Configuration
 
 .. attention::
    
-    The currently minimal Jenkins version is **2.289.3**
+    The currently minimal Jenkins version is **2.361.4**
 
     The currently minimal Tuleap version should be **12.11**
 


### PR DESCRIPTION
Due to upgrade to Java 11, the required minimal version changed

Part of [request #30740](https://tuleap.net/plugins/tracker/?aid=30740) Build Tuleap API with Java 11

Part of [request #30346](https://tuleap.net/plugins/tracker/?aid=30006) Build Tuleap Git Branch Source with Java 11

And part of [request #30006](https://tuleap.net/plugins/tracker/?aid=30006) Build Tuleap Authentication with Java 11