### PR TITLE
Added doc on meilisearch upgrade

### DIFF
--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -18,11 +18,12 @@ This is only a concern for you if you have deployed a :ref:`local Meilisearch in
 
 This upgrade requires to "update" the Meilisearch database to the `new 1.0.0 version <https://blog.meilisearch.com/v1-enterprise-ready-stable/>`_ 🎉.
 
-In order to do that, drop all the existing data and then ask Tuleap to re-index everything after you have upgraded the packages:
+In order to do that, drop all the existing data, restart tuleap-meilisearch, and then ask Tuleap to re-index everything after you have upgraded the packages:
 
 .. sourcecode:: shell
 
     rm -rf /var/lib/tuleap/fts_meilisearch_server/data.ms/
+    systemctl restart tuleap-meilisearch
     tuleap full-text-search:identify-all-items-to-index
     tuleap full-text-search:index-all-pending-items
 

--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -18,12 +18,13 @@ This is only a concern for you if you have deployed a :ref:`local Meilisearch in
 
 This upgrade requires to "update" the Meilisearch database to the `new 1.0.0 version <https://blog.meilisearch.com/v1-enterprise-ready-stable/>`_ 🎉.
 
-In order to do that, drop all the existing data, restart tuleap-meilisearch, and then ask Tuleap to re-index everything after you have upgraded the packages:
+In order to do that, drop all the existing data and then ask Tuleap to re-index everything after you have upgraded the packages:
 
 .. sourcecode:: shell
 
+    systemctl stop tuleap
     rm -rf /var/lib/tuleap/fts_meilisearch_server/data.ms/
-    systemctl restart tuleap-meilisearch
+    systemctl start tuleap
     tuleap full-text-search:identify-all-items-to-index
     tuleap full-text-search:index-all-pending-items
 


### PR DESCRIPTION
A bit was missing in the public documentation : 
You have to restart tuleap-meilisearch before re-indexing your data.