### PR TITLE
Set browser build target to Firefox 102

### DIFF
--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -8,7 +8,18 @@ Tuleap 14.10
 
   Tuleap 14.10 is currently under development.
 
-Nothing to mention.
+Minimal browser support raised to Firefox 102 ESR and Chrome 103
+----------------------------------------------------------------
+
+The best effort support is now Firefox 102 ESR and Chrome 103.
+Versions older than that do not work at all anymore to browse Tuleap.
+
+The previous minimal best effort browser version was Firefox 91 ESR which is out
+of security support since 9 months.
+
+:ref:`The recommendation is still to use the latest version of Mozilla Firefox, Microsoft Edge
+or Google Chrome <user_supported_browsers>`.
+
 
 Tuleap 14.9
 ===========

--- a/languages/en/user-guide/misc.rst
+++ b/languages/en/user-guide/misc.rst
@@ -44,10 +44,10 @@ Tuleap doesn't work at all with:
 
 * Internet Explorer, any version
 * Edge Legacy, any version
-* Firefox < 91 ESR
-* Chrome < 93
+* Firefox < 102 ESR
+* Chrome < 103
 
-Best effort: between Firefox 91 ESR / Chrome 93 and their latest version Tuleap might work (ie. most pages should show-up) but:
+Best effort: between Firefox 102 ESR / Chrome 103 and their latest version Tuleap might work (ie. most pages should show-up) but:
 
 * **YOU SHOULD NOT DO THAT**, your browser is vulnerable to **a lot** of public security issues and you are putting your whole infrastructure at risk.
 * There are no tests made at all.


### PR DESCRIPTION
Part of request #31952: Move build targets to current Firefox ESR