### PR TITLE
Document WITH/WITHOUT PARENT syntax for TQL

### DIFF
--- a/languages/en/user-guide/tql-artlink.rst
+++ b/languages/en/user-guide/tql-artlink.rst
@@ -1,0 +1,8 @@
+- Search for artifacts relationship:
+
+  * ``WITH PARENT`` matches all artifacts that have a parent artifact
+  * ``WITHOUT PARENT`` matches all artifacts that don't have a parent artifact
+  * ``WITH PARENT ARTIFACT = 123`` matches all artifacts that have artifact #123 as a parent
+  * ``WITHOUT PARENT ARTIFACT = 123`` matches all artifacts that don't have artifact #123 as a parent
+  * ``WITH PARENT TRACKER = 'epic'`` matches all artifacts that have an artifact from tracker ``epic`` (regardless of the project) as a parent
+  * ``WITHOUT PARENT TRACKER = 'epic'`` matches all artifacts that don't have an artifact from tracker ``epic`` (regardless of the project) as a parent

--- a/languages/en/user-guide/tql.rst
+++ b/languages/en/user-guide/tql.rst
@@ -54,7 +54,7 @@ Currently, the language supports:
 - Dynamic value for list fields bound to users: ``MYSELF()``.
 
   * ``assigned_to = MYSELF()`` matches all artifacts where assigned_to is equal to the current user.
-   
+
 - Search in comments:
 
   * ``@comments = 'Lorem ipsum'`` matches all artifacts where at least one follow-up comment contains the string ``lorem ipsum``
@@ -62,14 +62,16 @@ Currently, the language supports:
   * ``@comments != ''`` returns the list of artifacts with at least one comment
   * When searching in comments, you should be aware of some limitations:
      * Searches are done for words longer than 3 characters
-     * Some words are not taken in account because they are too common (like ``the``, ``a``, …) 
-     
+     * Some words are not taken in account because they are too common (like ``the``, ``a``, …)
+
 - Search in files:
 
   * ``attachment = 'minutes'`` matches all artifacts where there is at least one attached file with the filename "Minutes-20180101.docx" or the description "Minutes of last meeting" contains the string ``minutes``
   * ``attachment != 'minutes'`` matches all artifacts where there isn't any attached files with filename or description containing ``minutes``.
   * ``attachment = ''`` matches all artifacts without any attached files
   * ``attachment != ''`` matches all artifacts that have at least one attached file
+
+.. include:: tql-artlink.rst
 
 To construct a query you can combine all these elements.
 
@@ -208,7 +210,9 @@ Currently, the query supports:
   * For @submitted_on and @last_update_date: the empty string ``''`` cannot be used. Those fields always have a value, therefore the comparison to "empty" is not useful.
   * For @submitted_by, @last_update_by and @assigned_to: ``string`` matching a user, ``MYSELF()``
 
-  Example::
+.. include:: tql-artlink.rst
+
+Example::
 
     @title = 'documentation' AND @status = OPEN() AND @last_update_date > NOW() - 1w
     //Returns all open artifacts with 'documentation' in the title that have been


### PR DESCRIPTION
Part of [story #32281][0]: Search artifacts with/without parents via TQL

[0]: https://tuleap.net/plugins/tracker/?aid=32281