### PR TITLE
Extract kanban documentation

### DIFF
--- a/languages/en/user-guide/agile-dashboard.rst
+++ b/languages/en/user-guide/agile-dashboard.rst
@@ -19,8 +19,6 @@ or the remaining effort.
 Interactive actions currently include on the fly assigning, edition of the remaining effort and
 the drag'n'drop within a workflow.
 
-Tuleap also support Kanban methodology with a dedicated cardwall.
-
 Creating an Agile Dashboard
 ---------------------------
 
@@ -128,7 +126,7 @@ A product owner can populate a backlog either going directly to the "Top Backlog
 
 Explicit backlog
 ~~~~~~~~~~~~~~~~
-The top backlog planning will contains artifact you choose. They are added inside when you directly add them in top backlog view. 
+The top backlog planning will contains artifact you choose. They are added inside when you directly add them in top backlog view.
 
 On every single artifact that can be used in a top backlog planning you will have a link to add it to the top backlog.
 
@@ -280,104 +278,3 @@ When used in combination with Tuleap Test Management, the Backlog can be covered
    :name: Test plan over a release
 
 The full documentation is available in :ref:`Test Management <testmgmt_link_tests_requirements>` section.
-
-.. _kanban:
-
-Using a Kanban
---------------
-
-To enter a Kanban, go to the Agile Dashboard service of your project. All your Kanbans are displayed on the right hand side of the screen.
-
-.. figure:: ../images/screenshots/agiledashboard/kanban/kanban-list.png
-   :align: center
-   :alt: Kanban list
-   :name: Kanban list
-   :width: 800px
-
-   Agile Dashboard: Kanban List
-
-If you do not have any Kanban yet, you have two choices:
-
-1. Create a Kanban on your own
-2. Let Tuleap take care of it for you (``Start scrum`` button or ``Agile Dashboard Administration > Kanban > Activate Kanban``)
-
-Creating your Kanban from scratch
-`````````````````````````````````
-
-To create your own Kanban, you will need to create a tracker.
-Once your tracker has been created, go to the Agile Dashboard service of your project.
-Click on the ``Add a Kanban`` button located in the header of the right hand side section.
-In the modal, enter a name for your Kanban, select your newly created tracker and validate.
-
-.. figure:: ../images/screenshots/agiledashboard/kanban/create-new-kanban.png
-   :align: center
-   :alt: Create a new kanban
-   :name: Create a new kanban
-   :width: 800px
-
-   Agile Dashboard: Kanban creation
-
-A new Kanban appears in the Kanban section. Click on ``Cardwall`` to open it.
-
-Configure the card fields
-`````````````````````````
-
-Card fields are tracker fields to be displayed in the Kanban cards (only in expanded view).
-For instance you can easily display who is the creator of the card, who are the assignees, what is the priority etc.
-You can also define the card's background color.
-
-.. figure:: ../images/screenshots/agiledashboard/kanban/kanban-card-fields.png
-   :align: center
-   :alt: Cards fields
-   :name: Cards fields
-   :width: 500px
-
-   Agile Dashboard: Card fields in Kanban
-
-To do so, you have to configure the :ref:`semantic_color` in the tracker administration (``my_tracker > Administration > Manage Semantic > Card Semantic``).
-
-Filtered Kanban
-```````````````
-
-Your Kanban can be filtered using the public reports of its tracker.
-For instance, let's imagine you want to setup a filter showing the tasks assigned to the current user accessing the Kanban. To do so, you have to:
-
-1. Define a public report (ex: ``assigned_to = MYSELF()``)
-2. Go back to your Kanban
-3. Click on ``Edit this Kanban``
-4. Choose your report in the ``Tracker report filters`` section
-5. Save
-
-Once it is done, a filter selectbox appears in the header of the Kanban.
-
-.. figure:: ../images/screenshots/agiledashboard/kanban/filtered-kanban.png
-   :align: center
-   :alt: Filtered kanban
-   :name: Filtered kanban
-   :width: 800px
-
-   Agile Dashboard: Filtered Kanban
-
-Your Kanban will be reloaded with cards matching the query defined in the report, each time you change the filter.
-
-.. NOTE:: Filtered Kanbans are not working with the realtime feature of Tuleap.
-
-Add a Kanban to a dashboard
-```````````````````````````
-
-You can add your Kanban to one of your dashboards as a widget.
-To do it, click on the ``Add to dashboard`` button and select the target dashboard in the dropdown.
-
-.. figure:: ../images/screenshots/agiledashboard/kanban/filtered-kanban-widget.png
-   :align: center
-   :alt: Filtered kanban widget
-   :name: Filtered kanban widget
-   :width: 800px
-
-   Agile Dashboard: Kanban widget
-
-If a filter is selected when adding the widget to the dashboard, then the Kanban widget will be filtered too.
-It is particularly interesting when you want to have several views for a same Kanban.
-To edit the current filter, all you have to do is to click on the cog icon in the widget header and choose another filter.
-
-.. NOTE:: You can't add more than one Kanban widget per dashboard.

--- a/languages/en/user-guide/kanban.rst
+++ b/languages/en/user-guide/kanban.rst
@@ -1,0 +1,105 @@
+.. _kanban:
+
+Kanban
+======
+
+Tuleap supports Kanban methodology with a dedicated cardwall.
+
+Using a Kanban
+--------------
+
+To enter a Kanban, go to the Agile Dashboard service of your project. All your Kanban boards are displayed on the right hand side of the screen.
+
+.. figure:: ../images/screenshots/agiledashboard/kanban/kanban-list.png
+   :align: center
+   :alt: Kanban list
+   :name: Kanban list
+   :width: 800px
+
+   Kanban List
+
+If you do not have any Kanban yet, you have two choices:
+
+1. Create a Kanban on your own
+2. Let Tuleap take care of it for you (``Start scrum`` button or ``Agile Dashboard Administration > Kanban > Activate Kanban``)
+
+Creating your Kanban from scratch
+`````````````````````````````````
+
+To create your own Kanban, you will need to create a tracker.
+Once your tracker has been created, go to the Agile Dashboard service of your project.
+Click on the ``Add a Kanban`` button located in the header of the right hand side section.
+In the modal, enter a name for your Kanban, select your newly created tracker and validate.
+
+.. figure:: ../images/screenshots/agiledashboard/kanban/create-new-kanban.png
+   :align: center
+   :alt: Create a new kanban
+   :name: Create a new kanban
+   :width: 800px
+
+   Kanban creation
+
+A new Kanban appears in the Kanban section. Click on ``Cardwall`` to open it.
+
+Configure the card fields
+`````````````````````````
+
+Card fields are tracker fields to be displayed in the Kanban cards (only in expanded view).
+For instance you can easily display who is the creator of the card, who are the assignees, what is the priority etc.
+You can also define the card's background color.
+
+.. figure:: ../images/screenshots/agiledashboard/kanban/kanban-card-fields.png
+   :align: center
+   :alt: Cards fields
+   :name: Cards fields
+   :width: 500px
+
+   Card fields in Kanban
+
+To do so, you have to configure the :ref:`semantic_color` in the tracker administration (``my_tracker > Administration > Manage Semantic > Card Semantic``).
+
+Filtered Kanban
+```````````````
+
+Your Kanban can be filtered using the public reports of its tracker.
+For instance, let's imagine you want to setup a filter showing the tasks assigned to the current user accessing the Kanban. To do so, you have to:
+
+1. Define a public report (ex: ``assigned_to = MYSELF()``)
+2. Go back to your Kanban
+3. Click on ``Edit this Kanban``
+4. Choose your report in the ``Tracker report filters`` section
+5. Save
+
+Once it is done, a filter selectbox appears in the header of the Kanban.
+
+.. figure:: ../images/screenshots/agiledashboard/kanban/filtered-kanban.png
+   :align: center
+   :alt: Filtered kanban
+   :name: Filtered kanban
+   :width: 800px
+
+   Filtered Kanban
+
+Your Kanban will be reloaded with cards matching the query defined in the report, each time you change the filter.
+
+.. NOTE:: Filtered Kanbans are not working with the realtime feature of Tuleap.
+
+Add a Kanban to a dashboard
+```````````````````````````
+
+You can add your Kanban to one of your dashboards as a widget.
+To do it, click on the ``Add to dashboard`` button and select the target dashboard in the dropdown.
+
+.. figure:: ../images/screenshots/agiledashboard/kanban/filtered-kanban-widget.png
+   :align: center
+   :alt: Filtered kanban widget
+   :name: Filtered kanban widget
+   :width: 800px
+
+   Kanban widget
+
+If a filter is selected when adding the widget to the dashboard, then the Kanban widget will be filtered too.
+It is particularly interesting when you want to have several views for a same Kanban.
+To edit the current filter, all you have to do is to click on the cog icon in the widget header and choose another filter.
+
+.. NOTE:: You can't add more than one Kanban widget per dashboard.

--- a/languages/en/user.rst
+++ b/languages/en/user.rst
@@ -9,6 +9,7 @@ User guide
    user-guide/writing-in-tuleap
    user-guide/project-admin
    user-guide/agile-dashboard
+   user-guide/kanban
    user-guide/program-management
    user-guide/baseline
    user-guide/tracker


### PR DESCRIPTION
Kanban will soon be a whole service, outside of Agile Dashboard. It deserves its own documentation.

Since the legacy is the default behavior, screenshots and documentation content are kept as is until the split becomes the default.

Part of [story #33646][0]: access Kanban in a dedicated service

[0]: https://tuleap.net/plugins/tracker/?aid=33646