### PR TITLE
Mention upgrade to Meilisearch 1.3.1 in the deployment guide

### DIFF
--- a/languages/en/deployment-guide/14.x.rst
+++ b/languages/en/deployment-guide/14.x.rst
@@ -9,7 +9,17 @@ Tuleap 14.12
   Tuleap 14.12 is currently under development.
 
 
-Nothing to mention.
+Upgrade of the local Meilisearch instance from 1.2 to 1.3
+---------------------------------------------------------
+
+If you have deployed a :ref:`local Meilisearch instance <fts-local-meilisearch>` it will be automatically
+upgraded to the 1.3.1 version. The process is automatic when the server is restarted after its update.
+
+The upgrade will re-index all the items. Until the process is completed, some items might not be found when
+searching, and an increased load on your instance is expected.
+
+Administrators having deployed an independent Meilisearch instance should also
+`upgrade it <https://www.meilisearch.com/docs/learn/update_and_migration/updating>`_.
 
 Tuleap 14.11
 ============


### PR DESCRIPTION
Part of request #33659 Meilisearch: 1.2.0 -> 1.3.1