### PR TITLE
Mention the EOL of MySQL 5.7 and update installation requirements

### DIFF
--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -8,6 +8,14 @@ Tuleap 15.2
 
   Tuleap 15.2 is currently under development.
 
+End of support of MySQL 5.7
+---------------------------
+
+MySQL 5.7 has reached its end of life and therefore is not supported by Tuleap anymore.
+You must upgrade to MySQL 8.0.
+
+You can report to :ref:`the upgrade guide for more information <mysql80_upgrade>`.
+
 Tuleap 15.1
 ===========
 

--- a/languages/en/installation-guide/step-by-step/requirements.rst
+++ b/languages/en/installation-guide/step-by-step/requirements.rst
@@ -17,7 +17,7 @@ The server will need an Internet connection as it will download external package
 Database
 ````````
 
-Database must be MySQL v8.0. As an alternative, MariaDB 10.3 can be used but was never tested in production.
+Database must be MySQL v8.0.
 
 The database **must** be dedicated to Tuleap. Either it's a local installation (as described below, perfect for small & medium instances) or provided by an external service.
 


### PR DESCRIPTION
Related to:
* request #34715: Tuleap no longer start with MySQL 5.7
* request #35070: Drop MariaDB 10.3 tests