### PR TITLE
Removal of PHP 7.4 dependencies

### DIFF
--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -8,6 +8,24 @@ Tuleap 15.3
 
   Tuleap 15.3 is currently under development.
 
+Removal of remaining dependencies to PHP 7.4 packages
+-----------------------------------------------------
+
+The remaining dependencies to PHP 7.4 packages have been removed.
+After the upgrade you can remove the packages from your system.
+
+On CentOS/RHEL 7:
+
+.. sourcecode:: shell
+
+    yum remove php74\*
+
+On Rocky Linux 9:
+
+.. sourcecode:: shell
+
+    dnf remove php74\*
+
 Tuleap 15.2
 ===========
 


### PR DESCRIPTION
MediaWiki 1.35 was the last user of PHP 7.4 packages. They are not more needed anymore.

Part of [story #35103](https://tuleap.net/plugins/tracker/?aid=35103): upgrade to MediaWiki 1.39