### PR TITLE
Upgrade documentation should use dnf

### DIFF
--- a/languages/en/installation-guide/step-by-step/upgrade.rst
+++ b/languages/en/installation-guide/step-by-step/upgrade.rst
@@ -13,7 +13,7 @@ As root, run:
 
 .. sourcecode:: shell
 
-    yum check-update tuleap\*
+    dnf check-update tuleap\*
 
 
 Upgrade
@@ -29,7 +29,7 @@ Run as root:
     systemctl stop tuleap nginx httpd
 
     # Upgrade packages
-    yum update
+    dnf update
 
     # Deploy site configurations, run database migration & co
     tuleap-cfg site-deploy


### PR DESCRIPTION
The Upgrade documentation as it stands today uses yum instead of dnf.  
As we have sent CentOS into legacy mode, we should use DNF instead. 