### PR TITLE
$sys_nb_backend_workers removed from local.inc

### DIFF
--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -8,7 +8,20 @@ Tuleap 15.5
 
   Tuleap 15.5 is currently under development.
 
-Nothing to mention.
+``$sys_nb_backend_workers`` removed from ``local.inc``
+------------------------------------------------------
+
+The configuration variable ``$sys_nb_backend_workers``,
+used for asynchronous job processing (see :ref:`backend workers guide<installation_redis>`),
+is now set via ``tuleap config-set``.
+
+It is recommended to remove it from ``/etc/tuleap/conf/local.inc``. If you had set it specifically
+to a value greater than 2, you can keep your settings by issuing the following command:
+
+.. sourcecode:: shell
+
+    tuleap config-set sys_nb_backend_workers <NB>
+
 
 Tuleap 15.4
 ===========

--- a/languages/en/installation-guide/step-by-step/redis-configuration.rst
+++ b/languages/en/installation-guide/step-by-step/redis-configuration.rst
@@ -12,7 +12,7 @@ It's based on a notification queue managed by Redis and a worker that will proce
 Unlike "SystemEvents" there is no delay between the queue and the processing of the job.
 
 Generate a password :
-:: 
+::
 
     dd if=/dev/urandom bs=1 count=32 2>/dev/null | base64 -w 0 | rev | cut -b 2- | rev
 
@@ -38,10 +38,6 @@ Give it the correct permissions:
 
     chown codendiadm:codendiadm /etc/tuleap/conf/redis.inc
     chmod 640 /etc/tuleap/conf/redis.inc
-
-In ``/etc/tuleap/conf/local.inc`` you should set ``$sys_nb_backend_workers`` to a number greater than or equal to ``1``.
-This controls the number of workers to process background jobs. It should be adapted given your server workload.
-``2`` is a good starting value.
 
 All you have to do now is enable and launch the services and you should be able to access your instance.
 ::


### PR DESCRIPTION
The configuration variable `$sys_nb_backend_workers` is now set via the command `tuleap config-set sys_nb_backend_workers 2`.

Part of [story #35093][0]: execute custom code as artifact post action

[0]: https://tuleap.net/plugins/tracker/?aid=35093