### PR TITLE
Modification custom logo

### DIFF
--- a/languages/en/administration-guide/system-administration/customisations.rst
+++ b/languages/en/administration-guide/system-administration/customisations.rst
@@ -167,14 +167,29 @@ When it's done, cache must be invalidated with the command ``tuleap -c``
 
 **For the docker server you need to do this :**
 
-In the compose.yaml put a volume where you going to change the local path to a secure path inside your host.
-It will be present like this : ``local:/data``
+You will need to create a bridge between your host and the tuleap docker. To do that you going to do this :
 
-Like in the tuleap server had the two images in ``/var/lib/tuleap/images/``
+``docker run -v directory_files/:name_of_directory -v name_volume:/tuleap-data -t -i alpine sh`` 
 
-Then start docker with : ``docker compose up -d``
+* directory_files : it’s corresponding of where you put your two logos in your host.
+* name_of_directory : it’s the name of your directory in your container. You can put what you want.
+* name_volume : it’s the name of your volume that you are using for this modification. You can check all your volumes name with : ``docker volume ls``
+* alpine : we decide to put alpine because it’s a light image but you can choose an another one.
+* sh : it’s launching a bash environment.
 
-Now you can check of the configuration has been done correctly. You can go to your container that contain your website.
+Now you are going to remove the two existing logos in ``/tuleap-data/var/lib/tuleap/images``
+
+When this is done you can go exit the bash environment.
+
+And now you are going to copy your two png files between your host and the tuleap docker.
+
+``docker run -v directory_files/:name_of_directory -v name_volume:/tuleap-data -t -i cp name_of_directory/organization_logo.png /tuleap-data/var/lib/tuleap/images``
+
+Do the same for ``organization_logo_small.png``
+
+Now you can start docker with : ``docker compose up -d``
+
+Finally you can check on your docker website if everything work.
 
 Site content
 ------------

--- a/languages/en/administration-guide/system-administration/customisations.rst
+++ b/languages/en/administration-guide/system-administration/customisations.rst
@@ -149,9 +149,32 @@ Platform administrator must push two image files in PNG format:
 * ``/var/lib/tuleap/images/organization_logo.png`` (maximum size: 180×40px)
 * ``/var/lib/tuleap/images/organization_logo_small.png`` (maximum size: 40×40px)
 
-Once files are created, cache must be invalidated with ``tuleap -c``.
-
 The small version is used when the project sidebar is collapsed.
+
+**For the tuleap server you need to do this :**
+
+To import this two image files you need to remove first the two existing files.
+So you need to go to the folder : ``/var/lib/tuleap/images``.
+Delete ``organization_logo.png`` and ``organization_logo_small.png``
+
+Once you done that you can import now the new image files using the command ``scp``
+
+Here is an example : 
+
+* ``scp organization_logo.png root@ip_host://var/lib/tuleap/images/organization_logo.png``
+ 
+When it's done, cache must be invalidated with the command ``tuleap -c``
+
+**For the docker server you need to do this :**
+
+In the compose.yaml put a volume where you going to change the local path to a secure path inside your host.
+It will be present like this : ``local:/data``
+
+Like in the tuleap server had the two images in ``/var/lib/tuleap/images/``
+
+Then start docker with : ``docker compose up -d``
+
+Now you can check of the configuration has been done correctly. You can go to your container that contain your website.
 
 Site content
 ------------

--- a/languages/en/administration-guide/system-administration/customisations.rst
+++ b/languages/en/administration-guide/system-administration/customisations.rst
@@ -167,27 +167,21 @@ When it's done, cache must be invalidated with the command ``tuleap -c``
 
 **For the docker server you need to do this :**
 
-You will need to create a bridge between your host and the tuleap docker. To do that you going to do this :
+You will need to create a bridge between your host and the tuleap docker. To do that you are going to do this :
 
-``docker run -v directory_files/:name_of_directory -v name_volume:/tuleap-data -t -i alpine sh`` 
+``docker run --rm -v directory_files/:/pictures -v name_volume:/tuleap-data cp -f /pictures/organization_logo*.png /tuleap-data/var/lib/tuleap/images`` 
 
 * directory_files : it’s corresponding of where you put your two logos in your host.
-* name_of_directory : it’s the name of your directory in your container. You can put what you want.
 * name_volume : it’s the name of your volume that you are using for this modification. You can check all your volumes name with : ``docker volume ls``
-* alpine : we decide to put alpine because it’s a light image but you can choose an another one.
-* sh : it’s launching a bash environment.
 
-Now you are going to remove the two existing logos in ``/tuleap-data/var/lib/tuleap/images``
+In the first part of the command ``docker run --rm -v directory_files/:/pictures -v name_volume:/tuleap-data`` it will create a bridge between your host and the tuleap docker.
 
-When this is done you can go exit the bash environment.
+In the second part of this command ``cp -f /pictures/organization_logo*.png /tuleap-data/var/lib/tuleap/images`` it will copy all your logo files into the tuleap docker by erasing the old one.
 
-And now you are going to copy your two png files between your host and the tuleap docker.
+You can restart your container to see the modification : 
 
-``docker run -v directory_files/:name_of_directory -v name_volume:/tuleap-data -t -i cp name_of_directory/organization_logo.png /tuleap-data/var/lib/tuleap/images``
-
-Do the same for ``organization_logo_small.png``
-
-Now you can start docker with : ``docker compose up -d``
+* ``docker ps`` to know what is your container id.
+* ``docker restart container_id``
 
 Finally you can check on your docker website if everything work.
 


### PR DESCRIPTION
In this modification the objective is to be more precise on the PNG part. I made two parts, one for the tuleap server and one for the docker. It’s more useful to do this than to have generic information on the PNG part. I explain in details how to add the two PNG files in the tuleap server and in the docker. I think it’s important to be clear on those points to facilitate the user in his attempt to have a new logo on his page.