### PR TITLE
fix: Compose file should not have mailhog references

### DIFF
--- a/languages/en/installation-guide/docker/docker_compose.rst
+++ b/languages/en/installation-guide/docker/docker_compose.rst
@@ -64,7 +64,6 @@ Then create a ``compose.yaml`` file with following content:
         depends_on:
           - db
           - redis
-          - mailhog
         environment:
           - TULEAP_FQDN=${TULEAP_FQDN}
           - TULEAP_SYS_DBHOST=db


### PR DESCRIPTION
During my last refactor, we decided to throw Mailhog out of the stack.  
I obviously forgot to remove the dependance for Tuleap's container.  
Thanks TCottier for the information !