### PR TITLE
feat: Remove mention of backend workers with Redis

### DIFF
--- a/languages/en/administration-guide/system-administration/monitoring-with-prometheus.rst
+++ b/languages/en/administration-guide/system-administration/monitoring-with-prometheus.rst
@@ -22,7 +22,7 @@ Configuration of Tuleap
 -----------------------
 
 First step is to install a Redis server and to configure Tuleap to use it,
-checkout :ref:`backend workers guide<installation_redis>`.
+checkout the :ref:`Redis installation guide<installation_redis>`.
 
 After having installed and activated ``tuleap-plugin-prometheus-metrics`` rpm, you need to setup a password to access the
 data (by default data are private and there is no ways to make them accessible anonymously). To do so, you need to write

--- a/languages/en/installation-guide/step-by-step/redis-configuration.rst
+++ b/languages/en/installation-guide/step-by-step/redis-configuration.rst
@@ -3,13 +3,7 @@
 Redis Configuration
 ===================
 
-Backend workers are used to process asynchronous tasks. Currently it is used for:
-
-* Asynchronous actions like sending tracker notifications or :ref:`importing Jira issues <tracker-import-from-jira>`
-* :ref:`Monitoring with Prometheus<admin_monitoring_with_prometheus>`
-
-It's based on a notification queue managed by Redis and a worker that will process the the queue as soon as it's pushed.
-Unlike "SystemEvents" there is no delay between the queue and the processing of the job.
+Redis is used when using the :ref:`monitoring with Prometheus<admin_monitoring_with_prometheus>` feature.
 
 Generate a password :
 ::

--- a/languages/en/user-guide/trackers/administration/tracker-creation.rst
+++ b/languages/en/user-guide/trackers/administration/tracker-creation.rst
@@ -108,7 +108,6 @@ Import prerequisites
 
 Before doing the Jira issue import, you have to check the following points:
 
-* Redis must be enabled and :ref:`backend workers configured <installation_redis>`
 * Users email addresses are visible to anyone in the Jira configuration (must be done by each user)
 * The Jira user used to do the import must be administrator of your Jira project in order to have all the issues and all the content possible.
 


### PR DESCRIPTION
The only remaining direct usage of Redis is for the monitoring parts. Async event queue is backed by the DB by default now.

Part of request #37566: Support the async event queue using the DB instead of Redis