### PR TITLE
chore: Remove mention of Redis in TCE Docker deployment

### DIFF
--- a/languages/en/installation-guide/docker/docker_compose.rst
+++ b/languages/en/installation-guide/docker/docker_compose.rst
@@ -41,7 +41,7 @@ Tuleap Community
 
 .. warning::
 
-    The following section is meant for test purpose only. The databases (MySQL and Redis) are handled by Docker and it is not a recommended setup.
+    The following section is meant for test purpose only. The database (MySQL) is handled by Docker and it is not a recommended setup.
 
 
 Then create a ``compose.yaml`` file with following content:
@@ -63,7 +63,6 @@ Then create a ``compose.yaml`` file with following content:
           - tuleap-data:/data
         depends_on:
           - db
-          - redis
         environment:
           - TULEAP_FQDN=${TULEAP_FQDN}
           - TULEAP_SYS_DBHOST=db
@@ -71,8 +70,6 @@ Then create a ``compose.yaml`` file with following content:
           - SITE_ADMINISTRATOR_PASSWORD=${SITE_ADMINISTRATOR_PASSWORD}
           - DB_ADMIN_USER=root
           - DB_ADMIN_PASSWORD=${MYSQL_ROOT_PASSWORD}
-          - TULEAP_FPM_SESSION_MODE=redis
-          - TULEAP_REDIS_SERVER=redis
 
       # This is for test purpose only. It's not advised to run a production database as a docker container
       db:
@@ -83,17 +80,9 @@ Then create a ``compose.yaml`` file with following content:
         volumes:
           - db-data:/var/lib/mysql
 
-      # This is for test purpose only. It's not advised to run a production database as a docker container
-      redis:
-        image: redis:6
-        volumes:
-          - redis-data:/data
-        command: redis-server --appendonly yes --auto-aof-rewrite-percentage 20 --auto-aof-rewrite-min-size 200kb
-
     volumes:
       tuleap-data:
       db-data:
-      redis-data:
 
 Tuleap Enterprise
 `````````````````

--- a/languages/en/installation-guide/docker/images-configuration.rst
+++ b/languages/en/installation-guide/docker/images-configuration.rst
@@ -38,7 +38,7 @@ Site administration
 Redis
 #####
 
-* ``TULEAP_FPM_SESSION_MODE``: you can set it to ``redis`` so php sessions will be stored in a `Redis <https://redis.io>`_ K/V store. This also activate usage of redis for Tuleap (background events, etc).
+* ``TULEAP_FPM_SESSION_MODE``: you can set it to ``redis`` so php sessions will be stored in a `Redis <https://redis.io>`_ K/V store.
 * ``TULEAP_REDIS_SERVER``: needed if you set ``redis`` for ``TULEAP_FPM_SESSION_MODE``.
 * ``TULEAP_REDIS_PORT``: needed if redis is listening on port that is not ``6379`` (the default).
 * ``TULEAP_REDIS_PASSWORD``: needed if redis requires a password.

--- a/languages/en/installation-guide/step-by-step/redis-configuration.rst
+++ b/languages/en/installation-guide/step-by-step/redis-configuration.rst
@@ -4,6 +4,7 @@ Redis Configuration
 ===================
 
 Redis is used when using the :ref:`monitoring with Prometheus<admin_monitoring_with_prometheus>` feature.
+If you do not use it, your can skip this setup.
 
 Generate a password :
 ::


### PR DESCRIPTION
The only remaining usage of Redis in Tuleap is for the prometheus_metrics plugin is only usable with TEE.

Part of request #37566: Support the async event queue using the DB instead of Redis