### PR TITLE
docs: Document cross-tracker search API breaking change

### DIFF
--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -8,7 +8,12 @@ Tuleap 15.10
 
   Tuleap 15.10 is currently under development.
 
-Nothing to mention.
+API BREAKING CHANGE:
+--------------------
+
+``/api/cross_tracker_reports/{id}/content`` REST endpoint changed its default return format to "selectable".
+If you wish to use the previous return format, please add a parameter ``return_format=static``.
+Cross-tracker search widgets have been updated to request the static return format, they will keep functioning as before.
 
 Tuleap 15.9
 ===========


### PR DESCRIPTION
Part of story #38263 Choose my own columns based on field name (numeric, text, dates)