### PR TITLE
Initiate artidoc documentation

### DIFF
--- a/languages/en/installation-guide/step-by-step/install-packages.rst
+++ b/languages/en/installation-guide/step-by-step/install-packages.rst
@@ -5,7 +5,7 @@ Install packages
 
 `Tuleap Enterprise Edition <https://www.tuleap.org/product/tuleap-enterprise-edition-features>`__  is a special distribution of Tuleap crafted by `Enalean <https://enalean.com>`_ with more plugins and enhanced reliability.
 
-Tuleap Community Edition is the development version of Tuleap with a limited set of plugins. 
+Tuleap Community Edition is the development version of Tuleap with a limited set of plugins.
 
 
 Please choose one of the two editions :
@@ -41,6 +41,7 @@ Create a file ``/etc/yum.repos.d/tuleap.repo`` with the following content:
     tuleap-plugin-agiledashboard \
     tuleap-plugin-api-explorer \
     tuleap-plugin-archivedeleteditems \
+    tuleap-plugin-artidoc \
     tuleap-plugin-baseline \
     tuleap-plugin-botmattermost-agiledashboard \
     tuleap-plugin-botmattermost-git \

--- a/languages/en/installation-guide/step-by-step/install-plugins.rst
+++ b/languages/en/installation-guide/step-by-step/install-plugins.rst
@@ -94,6 +94,10 @@ Project management:
 
   * This module is part of :ref:`Tuleap Entreprise <tuleap-enterprise>`.
 
+* :ref:`artidoc <artidoc>`: Compose documents with artifacts.
+
+  * This module is part of :ref:`Tuleap Entreprise <tuleap-enterprise>`.
+
 
 File deliveries and documentation:
 

--- a/languages/en/user-guide/documents-and-files.rst
+++ b/languages/en/user-guide/documents-and-files.rst
@@ -5,6 +5,7 @@ Documents and files
    :maxdepth: 2
 
    documents-and-files/doc
+   documents-and-files/artidoc
    documents-and-files/mediawiki
    documents-and-files/wiki
    documents-and-files/frs

--- a/languages/en/user-guide/documents-and-files/artidoc.rst
+++ b/languages/en/user-guide/documents-and-files/artidoc.rst
@@ -1,0 +1,33 @@
+.. _artidoc:
+
+Artidoc
+=======
+
+.. note::
+
+  This module is part of :ref:`Tuleap Entreprise <tuleap-enterprise>`. It might
+  not be available on your installation of Tuleap.
+
+Context
+-------
+
+The goal is to let users interact with artifacts as if they are part of a document.
+
+This can covers the following use cases:
+
+* Requirement Management
+* FAQs
+* Meeting minutes
+* …
+
+Usage
+-----
+
+Artidoc is a dedicated type of document. Each section of the document is an artifact.
+
+Once the artidoc document created, it must be configured with a tracker. This tracker will be used to create new sections.
+
+Please note that the configuration can be changed during the lifetime of the document,
+the new selected tracker impacts only new sections, existing sections will stay untouched.
+
+

--- a/languages/en/user-guide/documents-and-files/doc.rst
+++ b/languages/en/user-guide/documents-and-files/doc.rst
@@ -84,32 +84,35 @@ Document Type
 
 Six types of documents are available:
 
-=================== ===============================================================
-Type                Description
-=================== ===============================================================
-File                Any type of document can be uploaded. From a PowerPoint
-                    presentation, to a simple picture or a full office document.
-                    Files are versioned, so you can add new versions on existing
-                    document.
+======================== ===============================================================
+Type                     Description
+======================== ===============================================================
+File                     Any type of document can be uploaded. From a PowerPoint
+                         presentation, to a simple picture or a full office document.
+                         Files are versioned, so you can add new versions on existing
+                         document.
 
-Online office file  Office files such as Word, Powerpoint or Excel documents can be
-                    viewed, created, and edited directly in your browser when the
-                    :ref:`ONLYOFFICE integration <onlyoffice-integration>` is
-                    active.
+Online office file       Office files such as Word, Powerpoint or Excel documents can be
+                         viewed, created, and edited directly in your browser when the
+                         :ref:`ONLYOFFICE integration <onlyoffice-integration>` is
+                         active.
 
-Link                Allows the user to target a document with a URL. The document
-                    will not be stored locally in the Document Manager.
+Link                     Allows the user to target a document with a URL. The document
+                         will not be stored locally in the Document Manager.
 
-Empty               The document will have no type. The user will be able to
-                    change the type after creation.
+Empty                    The document will have no type. The user will be able to
+                         change the type after creation.
 
-Wiki                The document can be created with the wiki service. Just
-                    enter the name of the corresponding wiki page. You can also
-                    use an existing wiki page name.
+Wiki                     The document can be created with the wiki service. Just
+                         enter the name of the corresponding wiki page. You can also
+                         use an existing wiki page name.
 
-Embedded file       HTML text that can be edited online. Embedded files are
-                    versioned.
-=================== ===============================================================
+Embedded file            HTML text that can be edited online. Embedded files are
+                         versioned.
+
+:ref:`Artidoc <artidoc>` Compose a document with artifacts. **Note:** This is part of
+                         :ref:`Tuleap Entreprise <tuleap-enterprise>`.
+======================== ===============================================================
 
 .. note::
 


### PR DESCRIPTION
Now that artidoc is not anymore an experimental plugin, we can start to document it.

Part of [story #38288](https://tuleap.net/plugins/tracker/?aid=38288): add a new section