### PR TITLE
fix: Do not install the project ownership plugin by default

### DIFF
--- a/languages/en/installation-guide/step-by-step/install-packages.rst
+++ b/languages/en/installation-guide/step-by-step/install-packages.rst
@@ -62,7 +62,6 @@ Create a file ``/etc/yum.repos.d/tuleap.repo`` with the following content:
     tuleap-plugin-mediawiki \
     tuleap-plugin-openidconnectclient \
     tuleap-plugin-program_management \
-    tuleap-plugin-project-ownership \
     tuleap-plugin-projectmilestones \
     tuleap-plugin-prometheus-metrics \
     tuleap-plugin-pullrequest \


### PR DESCRIPTION
Unless you know what you are doing you should not install this plugin. It brings additional hurdles and some parts can only managed with the REST API.