### PR TITLE
chore: Stop deploying docs.tuleap.org in the build image pipeline

### DIFF
--- a/Jenkinsfile-build-docs.tuleap.org
+++ b/Jenkinsfile-build-docs.tuleap.org
@@ -29,12 +29,5 @@ pipeline {
                 }
             }
         }
-        stage('Deploy') {
-            steps {
-                sshagent(['deploy-documentation-web01.enalean.com']) {
-                    sh 'ssh jenkins@web01.enalean.com ./update_docs.tuleap.org.sh'
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Part of some internal work art #108457