### PR TITLE
fix: TULEAP_VERSION should be set correctly on compose file

### DIFF
--- a/languages/en/installation-guide/docker/docker_compose.rst
+++ b/languages/en/installation-guide/docker/docker_compose.rst
@@ -109,7 +109,7 @@ Please check the :ref:`environment variables <docker-environment-variables>` to 
 
     services:
     tuleap:
-        image: docker.tuleap.org/tuleap-enterprise-edition:${TULEAP-VERSION}
+        image: docker.tuleap.org/tuleap-enterprise-edition:${TULEAP_VERSION}
         hostname: ${TULEAP_FQDN}
         restart: always
         ports:


### PR DESCRIPTION
Documentation is not defined correctly and leads to issues when pulling the image. 
Stating correctly the variable will fix the problem