### PR TITLE
Start development of 16.0

### DIFF
--- a/languages/en/deploy.rst
+++ b/languages/en/deploy.rst
@@ -15,6 +15,7 @@ file, the default is automatically set for you.
 .. toctree::
    :maxdepth: 1
 
+   deployment-guide/16.x.rst
    deployment-guide/15.x.rst
    deployment-guide/14.x.rst
    deployment-guide/13.x.rst

--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -4,9 +4,7 @@ Tuleap 15.x
 Tuleap 15.13
 ============
 
-.. NOTE::
-
-  Tuleap 15.13 is currently under development.
+Nothing to mention.
 
 Tuleap 15.12
 ============

--- a/languages/en/deployment-guide/16.x.rst
+++ b/languages/en/deployment-guide/16.x.rst
@@ -1,0 +1,10 @@
+Tuleap 16.x
+###########
+
+Tuleap 16.0
+===========
+
+.. NOTE::
+
+  Tuleap 16.0 is currently under development.
+


### PR DESCRIPTION
Start the development of Tuleap 16.0

Since it is the beginning of a new release cycle, I've added the file `deployment-guide/16.x.rst`.