### PR TITLE
chore: replace deprecated sass functions and imports

### DIFF
--- a/languages/en/_themes/tuleap_org/style/_backbone.scss
+++ b/languages/en/_themes/tuleap_org/style/_backbone.scss
@@ -1,6 +1,14 @@
+@use "./backbone/basic-elements";
+@use "./backbone/form";
+@use "./backbone/card";
+@use "./backbone/badge";
+@use "./backbone/header";
+@use "./backbone/footer";
+@use "./variables";
+
 body {
     min-height: 100vh;
-    padding: $header-height 0 0;
+    padding: variables.$header-height 0 0;
     background: #ffffff;
     font-family: 'OpenSans', Helvetica, Arial, sans-serif;
 
@@ -9,38 +17,30 @@ body {
         overflow: hidden;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
-        padding: $header-pinned-height 0 0;
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
+        padding: variables.$header-pinned-height 0 0;
     }
 
     > main {
-        min-height: calc(100vh - #{$footer-height});
+        min-height: calc(100vh - #{variables.$footer-height});
 
         .container {
-            width: $container-width;
+            width: variables.$container-width;
             margin: 0 auto;
             padding: 50px 0;
 
-            @media screen and (min-width: #{$big-screen-size}) {
-                max-width: $big-screen-size;
+            @media screen and (min-width: #{variables.$big-screen-size}) {
+                max-width: variables.$big-screen-size;
             }
 
-            @media screen and (max-width: #{$small-screen-size}) {
+            @media screen and (max-width: #{variables.$small-screen-size}) {
                 width: 100%;
                 padding: 50px 20px;
             }
         }
 
-        @media screen and (max-width: #{$tiny-screen-size}) {
-            min-height: calc(100vh - #{$footer-height} + (#{$header-height} - #{$header-pinned-height}));
+        @media screen and (max-width: #{variables.$tiny-screen-size}) {
+            min-height: calc(100vh - #{variables.$footer-height} + (#{variables.$header-height} - #{variables.$header-pinned-height}));
         }
     }
 }
-
-@import 'backbone/basic-elements';
-@import 'backbone/form';
-@import 'backbone/card';
-@import 'backbone/badge';
-
-@import 'backbone/header';
-@import 'backbone/footer';

--- a/languages/en/_themes/tuleap_org/style/_doc.scss
+++ b/languages/en/_themes/tuleap_org/style/_doc.scss
@@ -1,9 +1,12 @@
+@use "./variables";
+@use "sass:color";
+
 body {
     &.pinned .doc-menu {
-        height: calc(100vh - #{$header-pinned-height} - 20px);
+        height: calc(100vh - #{variables.$header-pinned-height} - 20px);
     }
 
-    @each $name, $hexa in $guides {
+    @each $name, $hexa in variables.$guides {
         &.#{$name} {
             .doc-menu li > a.current,
             .doc-content a,
@@ -14,7 +17,7 @@ body {
 
             .doc-menu li.toctree-l3 > a::before,
             .doc-menu li.toctree-l3 > ul::before {
-                background: transparentize($hexa, .1);
+                background: color.scale($hexa, $alpha: -10%);
             }
 
             .doc-previous-next > a.button.outline {
@@ -23,13 +26,13 @@ body {
 
                 &:hover:not(:disabled),
                 &:focus:not(:disabled) {
-                    border-color: darken($hexa, 10%);
-                    background: transparentize($hexa, .9);
+                    border-color: color.adjust($hexa, $lightness: -10%);
+                    background: color.scale($hexa, $alpha: -90%);
                 }
 
                 &:active {
-                    border-color: darken($hexa, 12%);
-                    background: transparentize($hexa, .8);
+                    border-color: color.adjust($hexa, $lightness: -12%);
+                    background: color.scale($hexa, $alpha: -80%);
                 }
             }
         }
@@ -46,17 +49,17 @@ body {
     top: 100px;
     flex: 0 0 auto;
     width: 300px;
-    height: calc(100vh - #{$header-height});
+    height: calc(100vh - #{variables.$header-height});
     padding: 20px 20px 50px 0;
     overflow-y: auto;
 
-    @media screen and (max-width: #{$small-screen-size}) {
+    @media screen and (max-width: #{variables.$small-screen-size}) {
         padding: 20px 20px 50px;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         top: 80px;
-        height: calc(100vh - #{$header-pinned-height});
+        height: calc(100vh - #{variables.$header-pinned-height});
         margin: 0 0 0 -295px;
         transition: margin 100ms;
 
@@ -97,7 +100,7 @@ body {
             margin: 0 0 20px;
 
             > a {
-                color: $grey;
+                color: variables.$grey;
                 font-weight: 600;
                 text-transform: uppercase;
 
@@ -131,11 +134,11 @@ body {
                 left: -8px;
                 width: 2px;
                 height: 100%;
-                background: transparentize($orange, .1);
+                background: color.scale(variables.$orange, $alpha: -10%);
             }
 
             a {
-                color: $grey;
+                color: variables.$grey;
             }
         }
 
@@ -152,7 +155,7 @@ body {
             display: block;
             position: relative;
             padding: 5px;
-            color: $light-grey;
+            color: variables.$light-grey;
             line-height: 18px;
 
             &:hover::after {
@@ -164,12 +167,12 @@ body {
             &:hover,
             &:active,
             &:focus {
-                color: $black;
+                color: variables.$black;
                 text-decoration: none;
             }
 
             &.current {
-                color: $orange;
+                color: variables.$orange;
             }
 
             .toctree-expand {
@@ -196,7 +199,7 @@ body {
     display: none;
     margin: 0 25px 0 0;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         display: inline-block;
     }
 }
@@ -217,7 +220,7 @@ body {
 
     .doc-breadcrumb-separator {
         margin: 0 7px 0 0;
-        color: $light-grey;
+        color: variables.$light-grey;
         font-size: 10px;
     }
 }
@@ -236,13 +239,13 @@ body {
         width: 1px;
         height: 100%;
         background-image: linear-gradient(to bottom,
-            $white 0,
-            transparentize($light-grey, .85) 50px,
-            transparentize($light-grey, .85) 100%
+            variables.$white 0,
+            color.scale(variables.$light-grey, $alpha: -85%) 50px,
+            color.scale(variables.$light-grey, $alpha: -85%) 100%
         );
     }
 
-    @media screen and (max-width: #{$small-screen-size}) {
+    @media screen and (max-width: #{variables.$small-screen-size}) {
         padding: 50px 20px;
     }
 
@@ -303,7 +306,7 @@ body {
     }
 
     .caption {
-        color: $light-grey;
+        color: variables.$light-grey;
         font-style: italic;
         text-align: center;
     }
@@ -351,47 +354,47 @@ body {
     }
 
     .attention {
-        border-left: 4px solid $red;
-        background: transparentize($red, .95);
+        border-left: 4px solid variables.$red;
+        background: color.scale(variables.$red, $alpha: -95%);
 
         > p {
-            color: $red;
+            color: variables.$red;
         }
 
         li::before {
-            color: $red;
+            color: variables.$red;
         }
     }
 
     .warning {
-        border-left: 4px solid $orange;
-        background: transparentize($orange, .95);
+        border-left: 4px solid variables.$orange;
+        background: color.scale(variables.$orange, $alpha: -95%);
 
         > p {
-            color: $orange;
+            color: variables.$orange;
         }
 
         li::before {
-            color: $orange;
+            color: variables.$orange;
         }
     }
 
     .note {
-        border-left: 4px solid $light-blue;
-        background: transparentize($light-blue, .95);
+        border-left: 4px solid variables.$light-blue;
+        background: color.scale(variables.$light-blue, $alpha: -95%);
 
         > p {
-            color: $light-blue;
+            color: variables.$light-blue;
         }
 
         li::before {
-            color: $light-blue;
+            color: variables.$light-blue;
         }
     }
 
     .important {
         border-left: 4px solid #28c4a0;
-        background: transparentize(#28c4a0, .95);
+        background: color.scale(#28c4a0, $alpha: -95%);
 
         > p {
             color: #00775c;
@@ -415,21 +418,21 @@ body {
         line-height: 18px;
 
         &.highlighttable {
-            border-color: transparentize($blue, .8);
-            background: transparentize($blue, .95);
+            border-color: color.scale(variables.$blue, $alpha: -80%);
+            background: color.scale(variables.$blue, $alpha: -95%);
 
             th,
             td {
-                border-color: transparentize($blue, .8);
+                border-color: color.scale(variables.$blue, $alpha: -80%);
             }
         }
 
         th {
             padding: 15px 10px;
             border-right: 1px solid #e8e8e8;
-            border-bottom: 1px solid transparentize($orange, .4);
+            border-bottom: 1px solid color.scale(variables.$orange, $alpha: -40%);
             background: #f8f8f8;
-            color: $grey;
+            color: variables.$grey;
             font-weight: 600;
             vertical-align: middle;
 
@@ -469,7 +472,7 @@ body {
         pre {
             border: 0;
             background: none;
-            color: $grey;
+            color: variables.$grey;
         }
     }
 
@@ -479,7 +482,7 @@ body {
 
     .doc-homepage-subtitle {
         margin: 0 0 10px;
-        color: $light-grey;
+        color: variables.$light-grey;
         font-size: 18px;
     }
 
@@ -498,7 +501,7 @@ body {
         flex: 0 1 auto;
         margin: 0 50px 0 0;
 
-        @media screen and (min-width: #{$big-screen-size}) {
+        @media screen and (min-width: #{variables.$big-screen-size}) {
             margin: 0 100px 0 0;
         }
     }
@@ -516,12 +519,12 @@ body {
         &:first-child {
             margin-right: 25px;
 
-            @media screen and (min-width: #{$big-screen-size}) {
+            @media screen and (min-width: #{variables.$big-screen-size}) {
                 margin-right: 50px;
             }
         }
 
-        @media screen and (min-width: #{$big-screen-size}) {
+        @media screen and (min-width: #{variables.$big-screen-size}) {
             width: 280px;
         }
     }

--- a/languages/en/_themes/tuleap_org/style/_fonts.scss
+++ b/languages/en/_themes/tuleap_org/style/_fonts.scss
@@ -1,3 +1,16 @@
+$-fa-font-path: "@fortawesome/fontawesome-free/webfonts/";
+
+@use "pkg:@fortawesome/fontawesome-free/css/fontawesome.css";
+@use "pkg:@fortawesome/fontawesome-free/scss/solid.scss" with (
+    $fa-font-path: $-fa-font-path
+);
+@use "pkg:@fortawesome/fontawesome-free/scss/regular.scss" with (
+    $fa-font-path: $-fa-font-path
+);
+@use "pkg:@fortawesome/fontawesome-free/scss/brands.scss" with (
+    $fa-font-path: $-fa-font-path
+);
+
 @font-face {
     font-family: 'OpenSans';
     font-style: normal;
@@ -57,9 +70,3 @@
         url('./files/open-sans-latin-800.woff2') format('woff2'), /* Super Modern Browsers */
         url('./files/open-sans-latin-800.woff') format('woff'); /* Modern Browsers */
 }
-
-
-@import '@fortawesome/fontawesome-free/css/fontawesome';
-@import '@fortawesome/fontawesome-free/css/solid';
-@import '@fortawesome/fontawesome-free/css/regular';
-@import '@fortawesome/fontawesome-free/css/brands';

--- a/languages/en/_themes/tuleap_org/style/_reset.scss
+++ b/languages/en/_themes/tuleap_org/style/_reset.scss
@@ -1,4 +1,3 @@
-// scss-lint:disable all
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, acronym, address, big, cite, code,

--- a/languages/en/_themes/tuleap_org/style/backbone/_badge.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_badge.scss
@@ -1,16 +1,18 @@
+@use "../variables";
+
 .badge {
     margin: 10px 0 30px;
     padding: 10px 15px;
-    border: 1px solid $black;
+    border: 1px solid variables.$black;
     border-radius: 50px;
-    background: $black;
-    color: $white;
+    background: variables.$black;
+    color: variables.$white;
     font-size: 12px;
     font-weight: 600;
     text-align: center;
     text-transform: uppercase;
 
-    @each $name, $hexa in $colors {
+    @each $name, $hexa in variables.$colors {
         &.#{$name} {
             border: 1px solid $hexa;
             background: $hexa;

--- a/languages/en/_themes/tuleap_org/style/backbone/_basic-elements.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_basic-elements.scss
@@ -1,11 +1,14 @@
+@use "../variables";
+@use "sass:color";
+
 ::selection {
-    background: $orange;
-    color: $white;
+    background: variables.$orange;
+    color: variables.$white;
 }
 
 h1 {
     margin: 20px 0 60px;
-    color: $grey;
+    color: variables.$grey;
     font-size: 52px;
     font-weight: 300;
     line-height: 66px;
@@ -13,7 +16,7 @@ h1 {
 
 h2 {
     margin: 0 0 20px;
-    color: $orange;
+    color: variables.$orange;
     font-size: 30px;
     font-weight: 400;
     line-height: 42px;
@@ -22,13 +25,13 @@ h2 {
 .section-title {
     width: 100%;
     margin: 0 0 50px;
-    color: $black;
+    color: variables.$black;
     font-size: 42px;
     font-weight: 300;
     line-height: 54px;
     text-align: center;
 
-    @each $name, $hexa in $colors {
+    @each $name, $hexa in variables.$colors {
         &.#{$name} {
             color: $hexa;
         }
@@ -44,7 +47,7 @@ h2 {
 
 h3 {
     margin: 0 0 10px;
-    color: transparentize($grey, .3);
+    color: color.scale(variables.$grey, $alpha: -30%);
     font-size: 22px;
     font-weight: 600;
     line-height: 30px;
@@ -53,7 +56,7 @@ h3 {
 
 h4 {
     margin: 0 0 10px;
-    color: transparentize($grey, .4);
+    color: color.scale(variables.$grey, $alpha: -40%);
     font-size: 16px;
     font-weight: 700;
     line-height: 30px;
@@ -62,7 +65,7 @@ h4 {
 
 h5 {
     margin: 0 0 10px;
-    color: transparentize($grey, .4);
+    color: color.scale(variables.$grey, $alpha: -40%);
     font-weight: 700;
     line-height: 30px;
 }
@@ -80,7 +83,7 @@ dt,
 dd,
 p {
     margin: 0 0 20px;
-    color: $grey;
+    color: variables.$grey;
     font-size: 16px;
     font-weight: 400;
     line-height: 26px;
@@ -110,11 +113,11 @@ dt {
 }
 
 span.highlighted {
-    @each $name, $hexa in $colors {
+    @each $name, $hexa in variables.$colors {
         &.#{$name} {
             padding: 0;
             border-radius: 0;
-            background-image: linear-gradient(to top, transparentize($hexa, .7) 0%, transparentize($hexa, .85) 100%);
+            background-image: linear-gradient(to top, color.scale($hexa, $alpha: -70%) 0%, color.scale($hexa, $alpha: -85%) 100%);
             background-repeat: no-repeat;
             background-position: 0 85%;
             background-size: 100% 20%;
@@ -130,10 +133,10 @@ span.highlighted {
 pre {
     margin: 0 0 20px;
     padding: 10px;
-    border: 1px solid transparentize($blue, .8);
+    border: 1px solid color.scale(variables.$blue, $alpha: -80%);
     border-radius: 4px;
-    background: transparentize($blue, .95);
-    color: darken(#6cd3ff, 40%);
+    background: color.scale(variables.$blue, $alpha: -95%);
+    color: color.adjust(#6cd3ff, $lightness: -40%);
     font-family: monospace;
     font-size: 14px;
     line-height: 24px;
@@ -141,10 +144,10 @@ pre {
 
 code {
     padding: 3px 7px;
-    border: 1px solid transparentize($blue, .8);
+    border: 1px solid color.scale(variables.$blue, $alpha: -80%);
     border-radius: 3px;
-    background: transparentize($blue, .95);
-    color: darken(#6cd3ff, 40%);
+    background: color.scale(variables.$blue, $alpha: -95%);
+    color: color.adjust(#6cd3ff, $lightness: -40%);
     font-family: monospace;
     font-size: 14px;
     line-height: 24px;
@@ -162,8 +165,8 @@ code.download {
     white-space: inherit;
 
     > span:first-child::before {
-        @extend .fa;
-        @extend .fa-download;
+        @extend .fa !optional;
+        @extend .fa-download !optional;
         margin-right: 4px;
     }
 }
@@ -174,7 +177,7 @@ strong {
 
 blockquote {
     margin: 0 0 20px;
-    color: $grey;
+    color: variables.$grey;
     font-size: 16px;
     line-height: 30px;
 
@@ -189,7 +192,7 @@ blockquote {
     > .quote {
         position: relative;
         top: 5px;
-        color: $orange;
+        color: variables.$orange;
         font-size: 30px;
         line-height: 0;
     }
@@ -210,7 +213,7 @@ ul {
 }
 
 li {
-    color: $grey;
+    color: variables.$grey;
     font-size: 16px;
     font-weight: 400;
     line-height: 26px;
@@ -220,7 +223,7 @@ li {
         position: relative;
         top: -3px;
         margin: 0 8px 0 0;
-        color: $orange;
+        color: variables.$orange;
         font-family: 'Font Awesome 6 Free';
         font-weight: 900;
         font-size: 8px;
@@ -246,7 +249,7 @@ ol > li {
 }
 
 a {
-    color: $orange;
+    color: variables.$orange;
     text-decoration: none;
 
     &:hover,
@@ -265,7 +268,7 @@ a.button,
     transition: top $button-transition, background $button-transition, box-shadow $button-transition, border-color $button-transition;
     border-radius: 4px;
     box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
-    color: $white;
+    color: variables.$white;
     font-size: 18px;
     line-height: 22px;
     text-align: center;
@@ -303,24 +306,24 @@ a.button,
         opacity: .6;
     }
 
-    @each $name, $hexa in $colors {
+    @each $name, $hexa in variables.$colors {
         &.#{$name} {
             border: 1px solid $hexa;
             background: $hexa;
 
             @if $name == 'white' {
-                color: $grey;
+                color: variables.$grey;
             }
 
             &:hover:not(:disabled),
             &:focus:not(:disabled) {
-                border-color: darken($hexa, 10%);
-                background: darken($hexa, 10%);
+                border-color: color.adjust($hexa, $lightness: -10%);
+                background: color.adjust($hexa, $lightness: -10%);
             }
 
             &:active, {
-                border-color: darken($hexa, 15%);
-                background: darken($hexa, 15%);
+                border-color: color.adjust($hexa, $lightness: -15%);
+                background: color.adjust($hexa, $lightness: -15%);
             }
 
             &.outline {
@@ -331,32 +334,32 @@ a.button,
 
                 &:hover:not(:disabled),
                 &:focus:not(:disabled) {
-                    border-color: darken($hexa, 10%);
-                    background: transparentize($hexa, .9);
+                    border-color: color.adjust($hexa, $lightness: -10%);
+                    background: color.scale($hexa, $alpha: -90%);
                 }
 
                 &:active {
-                    border-color: darken($hexa, 12%);
-                    background: transparentize($hexa, .8);
+                    border-color: color.adjust($hexa, $lightness: -12%);
+                    background: color.scale($hexa, $alpha: -80%);
                 }
             }
 
             &.no-border {
-                border-color: transparentize($hexa, .92);
-                background: transparentize($hexa, .94);
+                border-color: color.scale($hexa, $alpha: -92%);
+                background: color.scale($hexa, $alpha: -94%);
                 box-shadow: 0 2px 4px rgba(50, 50, 93, .05), 0 1px 3px rgba(0, 0, 0, .02);
                 color: $hexa;
 
                 &:hover:not(:disabled),
                 &:focus:not(:disabled) {
-                    border-color: transparentize($hexa, .9);
-                    background: transparentize($hexa, .9);
+                    border-color: color.scale($hexa, $alpha: -90%);
+                    background: color.scale($hexa, $alpha: -90%);
                     box-shadow: 0 4px 6px rgba(50, 50, 93, .05), 0 1px 3px rgba(0, 0, 0, .02);
                 }
 
                 &:active {
                     border-color: transparent;
-                    background: transparentize($hexa, .9);
+                    background: color.scale($hexa, $alpha: -90%);
                 }
             }
         }
@@ -367,8 +370,8 @@ kbd {
     display: inline-block;
     padding: 2px 4px;
     border-radius: 3px;
-    background: $black;
-    color: $white;
+    background: variables.$black;
+    color: variables.$white;
     font-family: monospace;
     font-size: 0.875rem;
     line-height: 1.25rem;

--- a/languages/en/_themes/tuleap_org/style/backbone/_card.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_card.scss
@@ -1,3 +1,6 @@
+@use "../variables";
+@use "sass:color";
+
 .card {
     display: flex;
     position: relative;
@@ -31,15 +34,15 @@
         margin: 0;
         padding: 15px 20px;
         border-radius: 0 0 4px 4px;
-        background: $white;
-        color: $grey;
+        background: variables.$white;
+        color: variables.$grey;
         font-size: 18px;
         font-weight: 600;
     }
 
-    @each $name, $hexa in $colors {
+    @each $name, $hexa in variables.$colors {
         &.#{$name} > .card-illustration {
-            background: linear-gradient(45deg, darken($hexa, 5%), lighten($hexa, 15%));
+            background: linear-gradient(45deg, color.adjust($hexa, $lightness: -5%), color.adjust($hexa, $lightness: 15%));
         }
     }
 }

--- a/languages/en/_themes/tuleap_org/style/backbone/_footer.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_footer.scss
@@ -1,28 +1,31 @@
+@use "../variables";
+@use "sass:color";
+
 footer {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: $footer-height;
-    background: $black;
+    height: variables.$footer-height;
+    background: variables.$black;
 }
 
 .footer-content {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    width: $container-width;
+    width: variables.$container-width;
 
-    @media screen and (min-width: #{$big-screen-size}) {
-        max-width: $big-screen-size;
+    @media screen and (min-width: #{variables.$big-screen-size}) {
+        max-width: variables.$big-screen-size;
     }
 
-    @media screen and (max-width: #{$small-screen-size}) {
+    @media screen and (max-width: #{variables.$small-screen-size}) {
         width: 100%;
         padding: 0 20px;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         padding: 20px;
     }
 }
@@ -57,7 +60,7 @@ footer {
         color: #909090;
 
         &:hover {
-            color: lighten(#909090, 20%);
+            color: color.adjust(#909090, $lightness: 20%);
             text-decoration: none;
         }
     }
@@ -86,7 +89,7 @@ footer {
         background: #505050;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         margin: 0 0 0 5px;
     }
 }
@@ -102,7 +105,7 @@ footer {
     }
 
     &:hover {
-        color: lighten(#606060, 20%);
+        color: color.adjust(#606060, $lightness: 20%);
         text-decoration: none;
 
         .footer-link-image {
@@ -110,7 +113,7 @@ footer {
         }
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         margin: 0 5px;
     }
 }

--- a/languages/en/_themes/tuleap_org/style/backbone/_form.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_form.scss
@@ -1,3 +1,6 @@
+@use "../variables";
+@use "sass:color";
+
 label {
     display: block;
     flex: 0 0 auto;
@@ -13,7 +16,7 @@ label {
         position: relative;
         top: -3px;
         left: 3px;
-        color: $red;
+        color: variables.$red;
         font-size: 8px;
     }
 
@@ -36,8 +39,8 @@ textarea {
     transition: border-color $input-transition, box-shadow $input-transition;
     border: 1px solid #dddddd;
     border-radius: 4px;
-    background: $white;
-    color: $black;
+    background: variables.$white;
+    color: variables.$black;
     font-family: inherit;
     font-size: 16px;
 
@@ -48,7 +51,7 @@ textarea {
     &:focus,
     &:active {
         transition: border-color $input-transition, box-shadow $input-transition;
-        box-shadow: inset 0 0 2px transparentize($black, .7);
+        box-shadow: inset 0 0 2px color.scale(variables.$black, $alpha: -70%);
     }
 
     &::placeholder {

--- a/languages/en/_themes/tuleap_org/style/backbone/_header.scss
+++ b/languages/en/_themes/tuleap_org/style/backbone/_header.scss
@@ -1,26 +1,29 @@
+@use "../variables";
+@use "sass:color";
+
 /* stylelint-disable selector-no-qualifying-type */
 body.pinned {
     header {
         position: fixed;
-        height: $header-pinned-height;
-        -webkit-transform: translate3d(0, 0, 0);
-        background: $white;
-        box-shadow: 0 1px 5px transparentize($black, .8);
+        height: variables.$header-pinned-height;
+        transform: translate3d(0, 0, 0);
+        background: variables.$white;
+        box-shadow: 0 1px 5px color.scale(variables.$black, $alpha: -80%);
     }
 
     .header-content {
-        height: $header-pinned-height;
+        height: variables.$header-pinned-height;
     }
 
     .header-logo-image {
         height: 50px;
     }
 
-    @each $name, $hexa in $guides {
+    @each $name, $hexa in variables.$guides {
         &.#{$name} header {
             .header-menu-item-container:hover {
                 .header-menu-item {
-                    color: lighten($hexa, 30%);
+                    color: color.adjust($hexa, $lightness: 30%);
                 }
             }
 
@@ -29,7 +32,7 @@ body.pinned {
 
                 &.active {
                     background: $hexa;
-                    color: $white;
+                    color: variables.$white;
                 }
             }
         }
@@ -48,12 +51,12 @@ body:not(.pinned) {
         }
 
         .header-burger {
-            color: $white;
+            color: variables.$white;
         }
 
         .header-menu {
-            @media screen and (max-width: #{$tiny-screen-size}) {
-                background: transparentize($black, .05);
+            @media screen and (max-width: #{variables.$tiny-screen-size}) {
+                background: color.scale(variables.$black, $alpha: -5%);
 
                 &:not(.show) {
                     display: none;
@@ -64,27 +67,27 @@ body:not(.pinned) {
         .header-menu-item-container:hover {
             .header-menu-item {
                 background: #000000;
-                color: $orange;
+                color: variables.$orange;
             }
         }
 
         .header-menu-item {
-            color: $white;
+            color: variables.$white;
         }
 
         .header-submenu {
             background: #000000;
 
-            @media screen and (max-width: #{$mobile-screen-size}) {
+            @media screen and (max-width: #{variables.$mobile-screen-size}) {
                 background: none;
             }
         }
 
         .header-submenu-item {
-            color: $white;
+            color: variables.$white;
 
             &:hover {
-                background: lighten(#000000, 7%);
+                background: color.adjust(#000000, $lightness: 7%);
             }
         }
     }
@@ -100,46 +103,46 @@ body:not(.pinned) {
         }
 
         .header-burger {
-            color: $white;
+            color: variables.$white;
         }
 
         .header-menu-item-container:hover {
             .header-menu-item {
-                background: darken($black, 5%);
-                color: $orange;
+                background: color.adjust(variables.$black, $lightness: -5%);
+                color: variables.$orange;
             }
         }
 
         .header-menu-item {
-            color: $white;
+            color: variables.$white;
 
             &.active {
-                background: $white;
-                color: $orange;
+                background: variables.$white;
+                color: variables.$orange;
             }
         }
 
         .header-submenu {
-            background: darken($black, 5%);
+            background: color.adjust(variables.$black, $lightness: -5%);
 
-            @media screen and (max-width: #{$mobile-screen-size}) {
+            @media screen and (max-width: #{variables.$mobile-screen-size}) {
                 background: none;
             }
         }
 
         .header-submenu-item {
-            color: $white;
+            color: variables.$white;
 
             &:hover {
-                background: darken($black, 10%);
+                background: color.adjust(variables.$black, $lightness: -10%);
             }
         }
     }
 
     &.orange header {
         .header-menu {
-            @media screen and (max-width: #{$tiny-screen-size}) {
-                background: transparentize(#e07e3b, .05);
+            @media screen and (max-width: #{variables.$tiny-screen-size}) {
+                background: color.scale(#e07e3b, $alpha: -5%);
 
                 &:not(.show) {
                     display: none;
@@ -148,11 +151,11 @@ body:not(.pinned) {
         }
     }
 
-    @each $name, $hexa in $guides {
+    @each $name, $hexa in variables.$guides {
         &.#{$name} header {
             .header-menu-item-container:hover .header-menu-item {
-                background: $black;
-                color: lighten($hexa, 10%);
+                background: variables.$black;
+                color: color.adjust($hexa, $lightness: 10%);
             }
 
             .header-menu-item {
@@ -160,7 +163,7 @@ body:not(.pinned) {
 
                 &.active {
                     background: $hexa;
-                    color: $white;
+                    color: variables.$white;
                 }
             }
         }
@@ -175,13 +178,13 @@ header {
     flex-direction: column;
     align-items: center;
     width: 100%;
-    height: $header-height;
+    height: variables.$header-height;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         position: fixed;
         width: 100vw;
-        height: $header-pinned-height;
-        -webkit-transform: translate3d(0, 0, 0);
+        height: variables.$header-pinned-height;
+        transform: translate3d(0, 0, 0);
     }
 }
 
@@ -189,20 +192,20 @@ header {
     display: flex;
     align-items: stretch;
     justify-content: space-between;
-    width: $container-width;
-    height: $header-height;
+    width: variables.$container-width;
+    height: variables.$header-height;
 
-    @media screen and (min-width: #{$big-screen-size}) {
-        max-width: $big-screen-size;
+    @media screen and (min-width: #{variables.$big-screen-size}) {
+        max-width: variables.$big-screen-size;
     }
 
-    @media screen and (max-width: #{$small-screen-size}) {
+    @media screen and (max-width: #{variables.$small-screen-size}) {
         width: 100%;
         padding: 0 20px;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
-        height: $header-pinned-height;
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
+        height: variables.$header-pinned-height;
     }
 }
 
@@ -218,7 +221,7 @@ header {
 .header-logo-image-orange-black {
     height: 60px;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         height: 50px;
     }
 }
@@ -234,11 +237,11 @@ header {
 
 .header-burger {
     display: none;
-    color: $orange;
+    color: variables.$orange;
     font-size: 40px;
     cursor: pointer;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         display: flex;
         align-items: center;
     }
@@ -248,22 +251,22 @@ header {
     display: flex;
     align-items: center;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         position: fixed;
-        top: calc(#{$header-pinned-height} - 10px);
+        top: calc(#{variables.$header-pinned-height} - 10px);
         left: 0;
         flex-direction: column;
         justify-content: center;
         width: 100vw;
-        height: calc(100vh - #{$header-pinned-height} + 10px);
-        background: transparentize($white, .05);
+        height: calc(100vh - #{variables.$header-pinned-height} + 10px);
+        background: color.scale(variables.$white, $alpha: -5%);
 
         &:not(.show) {
             display: none;
         }
     }
 
-    @media screen and (max-width: #{$mobile-screen-size}) {
+    @media screen and (max-width: #{variables.$mobile-screen-size}) {
         justify-content: stretch;
         overflow: scroll;
     }
@@ -272,8 +275,8 @@ header {
 .header-menu-item-container:hover {
     .header-menu-item {
         border-radius: 5px 5px 0 0;
-        background: $grey;
-        color: $white;
+        background: variables.$grey;
+        color: variables.$white;
         text-decoration: none;
 
         &:only-child {
@@ -299,7 +302,7 @@ span.header-menu-item {
     margin: 0 5px;
     padding: 13px 10px;
     border-radius: 5px;
-    color: $orange;
+    color: variables.$orange;
     font-size: 12px;
     font-weight: 600;
     letter-spacing: .5px;
@@ -308,8 +311,8 @@ span.header-menu-item {
     text-transform: uppercase;
 
     &.active {
-        background: $orange;
-        color: $white;
+        background: variables.$orange;
+        color: variables.$white;
     }
 
     &:active,
@@ -317,11 +320,11 @@ span.header-menu-item {
         text-decoration: none;
     }
 
-    @media screen and (max-width: #{$small-screen-size}) {
+    @media screen and (max-width: #{variables.$small-screen-size}) {
         padding: 10px 8px;
     }
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         margin: 15px 0;
         padding: 13px 10px;
         font-size: 18px;
@@ -336,16 +339,16 @@ span.header-menu-item {
     margin: -1px 5px 0;
     overflow: hidden;
     border-radius: 0 5px 5px;
-    background: $grey;
-    box-shadow: 0 10px 20px transparentize($black, .8);
+    background: variables.$grey;
+    box-shadow: 0 10px 20px color.scale(variables.$black, $alpha: -80%);
     pointer-events: none;
 
-    @media screen and (max-width: #{$tiny-screen-size}) {
+    @media screen and (max-width: #{variables.$tiny-screen-size}) {
         position: relative;
         margin: -15px 0 0;
         border-radius: 0 0 5px 5px;
     }
-    @media screen and (max-width: #{$mobile-screen-size}) {
+    @media screen and (max-width: #{variables.$mobile-screen-size}) {
         display: flex;
         background: none;
         box-shadow: none;
@@ -357,24 +360,24 @@ span.header-menu-item {
     display: flex;
     flex-direction: column;
     padding: 13px 10px;
-    color: transparentize($white, .1);
+    color: color.scale(variables.$white, $alpha: -10%);
     font-size: 13px;
     letter-spacing: .2px;
     text-decoration: none;
 
     &:hover {
-        background: $black;
-        color: transparentize($white, .1);
+        background: variables.$black;
+        color: color.scale(variables.$white, $alpha: -10%);
         text-decoration: none;
     }
-    @media screen and (max-width: #{$mobile-screen-size}) {
-        color: $black;
+    @media screen and (max-width: #{variables.$mobile-screen-size}) {
+        color: variables.$black;
     }
 }
 
 .header-submenu-item-details {
     margin: 10px 0 0;
-    color: transparentize($white, .5);
+    color: color.scale(variables.$white, $alpha: -5%);
     font-size: 10px;
     letter-spacing: .8px;
     line-height: normal;
@@ -382,5 +385,5 @@ span.header-menu-item {
 }
 
 section {
-    scroll-margin-top: $header-pinned-height;
+    scroll-margin-top: variables.$header-pinned-height;
 }

--- a/languages/en/_themes/tuleap_org/style/main.scss
+++ b/languages/en/_themes/tuleap_org/style/main.scss
@@ -1,6 +1,4 @@
-@import 'reset';
-@import 'fonts';
-@import 'variables';
-
-@import 'backbone';
-@import 'doc';
+@use "./reset";
+@use "./fonts";
+@use "./backbone";
+@use "./doc";

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-    "name": "tuleap-documentation-en",
-    "private": true,
-    "license": "GPL-2.0-or-later",
-    "devDependencies": {
-        "@fortawesome/fontawesome-free": "^6.6.0",
-        "sass": "^1.79.4",
-        "vite": "^5.4.8"
-    },
-    "scripts": {
-        "build": "vite build",
-        "watch": "vite build --watch"
-    }
+  "name": "tuleap-documentation-en",
+  "private": true,
+  "license": "GPL-2.0-or-later",
+  "type": "module",
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "^6.6.0",
+    "sass": "^1.79.4",
+    "vite": "^5.4.8"
+  },
+  "scripts": {
+    "build": "vite build",
+    "watch": "vite build --watch"
+  }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
+import { resolve } from "node:path";
+import process from "node:process";
 import { defineConfig } from "vite";
-const { resolve } = require("path");
+import { NodePackageImporter } from "sass";
 
 export default defineConfig({
     base: "/_static/assets/",
@@ -20,5 +22,13 @@ export default defineConfig({
         },
         outDir: resolve(__dirname, "languages/en/_themes/tuleap_org/static/assets/"),
         assetsDir: "",
+    },
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api: "modern",
+                importers: [new NodePackageImporter(process.cwd())]
+            }
+        }
     },
 });


### PR DESCRIPTION
Implements request #39744 Bring up to date docs SCSS styles

The "tuleap-org" theme styles should not be more broken than before :p.
No style change expected.

Why?
1. vite now uses the "modern" API for sass, the legacy JS API is
deprecated
2. vite now uses the NodePackageImporter, enabling `pkg:` imports
3. The styles now use `@use` instead of `@import`, which is deprecated (and
has weird scoping)
4. The styles no longer use deprecated functions such as
transparentize(), lighten() and darken()
