### PR TITLE
doc: review tuleap backup and add tips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ help:
 	@grep -E '^[a-zA-Z0-9_\-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 clean:
-	-rm -rf tmp
+	-rm -rf tmp/*
 	-rm -rf $(BUILDDIR)/*
 
 html: pre-build ## Make standalone HTML files
@@ -48,7 +48,7 @@ html: pre-build ## Make standalone HTML files
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
-singlehtml: pre-build ## Make a signle large HTML file
+singlehtml: pre-build ## Make a single large HTML file
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml/$(LANG)
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."

--- a/languages/en/administration-guide/system-administration/backup.rst
+++ b/languages/en/administration-guide/system-administration/backup.rst
@@ -3,10 +3,11 @@
 Backup/Restore
 ==============
 
+
 Backup Tuleap
 -------------
 
-This documentation is here to help you to set your backup up. Be careful with this, it's just a guide and you will probably want to backup more things
+This documentation is here to help you set up your backup. Be careful with this, it's just a guide and you will probably want to backup more things.
 
 If you installed Tuleap on a virtual environment and you are able to use snapshots, the simplest backup solution is to suspend tuleap services and then make a snapshot. Otherwise here are some tips to backup your Tuleap infrastructure:
 
@@ -24,12 +25,19 @@ On CentOS/RHEL 7:
     $ systemctl stop tuleap
     $ su - gitolite -c "gitolite writable @all off 'Backup in progress'"
 
+On Docker/Compose:
+
+.. code-block:: bash
+
+    $ cd /path_to_tuleap_compose
+    $ docker compose stop tuleap
+
 Don't forget to restart services once the backup is done.
 
 Database backup
 ```````````````
 
-Tuleap main database is "tuleap", but additionnal databases can be used for plugins. To show them use:
+Tuleap main database is ``tuleap``, but additionnal databases can be used for plugins. To show them use:
 
 .. code-block:: bash
 
@@ -41,24 +49,105 @@ Use mysqldump to backup all databases. You can also write a script to backup eac
 
     $ mysqldump -u codendiadm -p --all-databases > mybackup.sql
 
-Files backup
-````````````
+For docker you can use something like this:
 
-You need to save the following directories. **Be careful, you need to preserve the correct rights on files**:
+.. code-block:: bash
 
-    - /etc/tuleap
-    - /var/lib/tuleap
-    - /var/lib/gitolite
-    - /var/lib/mailman
+    # Backup
+    docker exec SQL_CONTAINER /usr/bin/mysqldump -u codendiadm -p --all-databases > sqldump_all_tuleap.sql
+
+    # Restore (use root user for an empty server)
+    cat sqldump_all_tuleap.sql | docker exec -i SQL_CONTAINER /usr/bin/mysql -u root -p
+
+
+.. _tuleap_data_paths:
+
+Tuleap data paths backup
+````````````````````````
+
+You need to save the following directories:
+
+  - /etc/nginx
+  - /etc/redis
+  - /etc/tuleap
+  - /var/lib/gitolite
+  - /var/lib/tuleap
 
 Some directories might not exists depending on your configurations (plugins installed or not).
+
 
 Restore Tuleap
 --------------
 
 As only data were backed up, you first need a Tuleap server to restore them. It can be your old server or a new server you have just installed following the installation guide. Then you will need to:
 
-    - suspend all services
-    - restore databases
-    - restore directories
-    - run the site-deploy tool ``tuleap-cfg site-deploy``
+  - suspend all services
+  - restore databases (from a sqldump is the safest method to ensure compatibility between instances)
+  - restore directories (you must remap uids/gids if restoring from another instance, see below)
+  - run the site-deploy tool ``tuleap-cfg site-deploy``
+  - restart services
+
+
+Backup/Restoration/Installation tips
+------------------------------------
+
+uids/gids
+`````````
+
+If you plan to restore a backup from an instance to a new one, its likely that linux user and group ids have changed in between.
+
+First you need to identify the old ids from your backup archive, looking for each of those files (that should be owned by) :
+
+  - /etc/tuleap/conf/encryption_secret.key (codendiadm)
+  - /var/lib/gitolite/.gitolite/conf/gitolite.conf (gitolite)
+  - /var/lib/tuleap/ftp/pub (ftpadmin)
+
+
+Example use of ``ls -ldn`` to display those ids
+
+.. code-block:: bash
+
+    [root@tuleap ~]# ls -ldn /etc/tuleap/conf/encryption_secret.key /var/lib/gitolite/.gitolite/conf/gitolite.conf /var/lib/tuleap/ftp/pub
+    -r--------  1 980 980   64 Aug 16  2018 /etc/tuleap/conf/encryption_secret.key
+    -rw-rw----  1 976 976  867 Dec 21  2020 /var/lib/gitolite/.gitolite/conf/gitolite.conf
+    drwxr-xr-x 22 979 978 4096 Oct 22 08:59 /var/lib/tuleap/ftp/pub
+
+Then construct the map from the 3rd (uid) and 4th (gid) columns and the associated owner name
+  - usermap: ``980:codendiadm,976:gitolite,979:ftpadmin``
+  - groupmap: ``980:codendiadm,976:gitolite,978:ftpadmin``
+
+As you can see, for ftpadmin uids and gids are not the same in this example.
+
+Finally you can use a tool like ``rsync`` to help you remap your data while restoring/resyncing:
+
+.. code-block::
+
+    rsync [OPTION...] --usermap=980:codendiadm,976:gitolite,979:ftpadmin \
+                      --groupmap=980:codendiadm,976:gitolite,978:ftpadmin \
+                      SRC... [DEST]
+
+
+Moving Tuleap folders to an external disk
+`````````````````````````````````````````
+
+For the mentioned :ref:`tuleap data paths <tuleap_data_paths>`, you could move them on a **separate data disk** for easier backup.
+
+Like for the "Restore Tuleap" process decribed before, you need a running tuleap instance for the users/uids/gids to be created.
+
+Then, after suspending **all services including mysql** (if you want mysql to be on a data disk too) :
+  - move each directory to its new location, example: ``mv /etc/nginx /data/etc_nginx``
+  - then at your convenience:
+     * create symbolic links for each directory, example: ``ln -s /data/etc_nginx /etc/nginx``
+     * or use bind mounts through ``/etc/fstab`` like below (you need to ``mount`` them after updating the file)
+  - you can then restart services
+
+Example of bind mounts via local fstab
+
+.. code-block:: bash
+
+    /data/etc_nginx /etc/nginx none bind,nofail 0 0
+    /data/etc_redis /etc/redis none bind,nofail 0 0
+    /data/etc_tuleap /etc/tuleap none bind,nofail 0 0
+    /data/var_lib_gitolite /var/lib/gitolite none bind,nofail 0 0
+    /data/var_lib_mysql /var/lib/mysql none bind,nofail 0 0
+    /data/var_lib_tuleap /var/lib/tuleap none bind,nofail 0 0

--- a/languages/en/installation-guide/docker/docker_compose.rst
+++ b/languages/en/installation-guide/docker/docker_compose.rst
@@ -13,12 +13,12 @@ To explain this, this an example to guide you :
 
 If you intend to have a production environment :
 
-``/srv/tuleap/`` 
-	
+``/srv/tuleap/``
+
 If it's for a demo/test :
-	
-``/home/$USERNAME/Workspace/test-tuleap`` 
-	
+
+``/home/$USERNAME/Workspace/test-tuleap``
+
 
 
 Now you can create the file ``.env`` with this configuration :
@@ -30,7 +30,7 @@ Now you can create the file ``.env`` with this configuration :
     TULEAP_SYS_DBPASSWD="another strong password"
     SITE_ADMINISTRATOR_PASSWORD="and a third strong password"
 
-Please be aware that you need **double quotes** around your variables in order for docker to parse the whole string. 
+Please be aware that you need **double quotes** around your variables in order for docker to parse the whole string.
 
 Please check the :ref:`environment variables <docker-environment-variables>` to know what they stand for.
 
@@ -49,7 +49,7 @@ Then create a ``compose.yaml`` file with following content:
 .. code-block:: yaml
 
     services:
-      web:
+      tuleap:
         image: tuleap/tuleap-community-edition
         hostname: ${TULEAP_FQDN}
         restart: always
@@ -128,7 +128,7 @@ Please check the :ref:`environment variables <docker-environment-variables>` to 
         - TULEAP_FPM_SESSION_MODE=redis
         - TULEAP_REDIS_SERVER=${REDIS_FQDN}
 
-    volumes: 
+    volumes:
         tuleap-data:
 
 If you want to secure your server and use certificates, you may spawn a Reverse-Proxy in the stack.
@@ -153,25 +153,25 @@ Until you see something like:
 .. code-block::
 
     ...
-    web_1      | ***********************************************************************************************************
-    web_1      | * Your Tuleap fully qualified domain name is tuleap.example.com and it's IP address is 172.21.0.5         *
-    web_1      | ***********************************************************************************************************
-    web_1      | Setup Supervisord
-    web_1      | Let the place for Supervisord
-    web_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/backend_workers.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/crond.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/fpm.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/httpd.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/nginx.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/postfix.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/rsyslog.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/sshd.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/supervisord-server-credentials.ini" during parsing
-    web_1      | 2021-06-15 14:46:50,732 INFO Set uid to user 0 succeeded
-    web_1      | 2021-06-15 14:46:50,769 INFO RPC interface 'supervisor' initialized
+    tuleap_1      | ***********************************************************************************************************
+    tuleap_1      | * Your Tuleap fully qualified domain name is tuleap.example.com and it's IP address is 172.21.0.5         *
+    tuleap_1      | ***********************************************************************************************************
+    tuleap_1      | Setup Supervisord
+    tuleap_1      | Let the place for Supervisord
+    tuleap_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/backend_workers.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/crond.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/fpm.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,731 INFO Included extra file "/etc/supervisord.d/httpd.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/nginx.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/postfix.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/rsyslog.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/sshd.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Included extra file "/etc/supervisord.d/supervisord-server-credentials.ini" during parsing
+    tuleap_1      | 2021-06-15 14:46:50,732 INFO Set uid to user 0 succeeded
+    tuleap_1      | 2021-06-15 14:46:50,769 INFO RPC interface 'supervisor' initialized
     ...
 
 You can then quit the logs command (Ctrl+C) and open your browser at the address set in ``TULEAP_FQDN`` and that's it.
 
-The docker-compose file provided here is for general guidance and you should adapt it to your environment. 
+The docker-compose file provided here is for general guidance and you should adapt it to your environment.
 One of the main things you will want to configure is a proper email relay.

--- a/languages/en/installation-guide/docker/images-configuration.rst
+++ b/languages/en/installation-guide/docker/images-configuration.rst
@@ -1,7 +1,7 @@
 Docker images configuration
 ===========================
 
-This section covers the configuration details that applies to both images. 
+This section covers the configuration details that applies to both images.
 
 If you want the default configuration you can go to verify the image authencity.
 
@@ -52,10 +52,10 @@ Email
 
 .. warning::
 
-    Please note that not all plugins can be used with this configuration setting (:ref:`email_relay<emailrelay>`) and you might need to 
+    Please note that not all plugins can be used with this configuration setting (:ref:`email_relay<emailrelay>`) and you might need to
     customize the image to fit your needs.
 
-Passwords 
+Passwords
 `````````
 
 * We recommend at least 20 chars but only alphabetical & numbers,
@@ -80,8 +80,13 @@ for your end users you either need to:
 Certification Authority
 ```````````````````````
 
-If you manage your own trust chain, you might need to let container be aware of your own CA. 
+If you manage your own trust chain, you might need to let container be aware of your own CA.
 It's mainly useful when Tuleap should be able to communicate with a 3rd party systems (jenkins, jira, gitlab, webhooks servers, etc)
 exposed over TLS but with a certificate that is not part of the standard CA bundle.
 
 The extra CA must be mounted at the container root ``/extra_ca.pem``. Tuleap will ensure this CA is added to system's bundle automatically.
+
+Backup/Restore
+``````````````
+
+You probably want to take a look at the :ref:`Backup/Restore guide <backup>` to check data/folder structure for your docker volumes.


### PR DESCRIPTION
- update main tuleap data directories
- add "tip" for usermapping when restoring with rsync
- add "tip" for external disk storage (with symbolic links or bind-mount with fstab)
- add links from docker install guide
- rename/fix compose service name and setup output (web -> tuleap)
- fix typo in Makefile
- fix `make clean` command to not remove the tmp directory itself that is part of the repo files