### PR TITLE
chore: Give instructions to clean old MySQL user `dbauthuser`

### DIFF
--- a/languages/en/deployment-guide/15.x.rst
+++ b/languages/en/deployment-guide/15.x.rst
@@ -219,6 +219,8 @@ Nothing to mention.
 Tuleap 15.0
 ===========
 
+.. _dbauthuser_not_needed:
+
 Removal of the support of ForumML, CVS and of the management of system users and groups
 ---------------------------------------------------------------------------------------
 

--- a/languages/en/deployment-guide/16.x.rst
+++ b/languages/en/deployment-guide/16.x.rst
@@ -8,7 +8,16 @@ Tuleap 16.1
 
   Tuleap 16.1 is currently under development.
 
-Nothing to mention.
+Removal of the MySQL user ``dbauthuser``
+----------------------------------------
+
+In :ref:`Tuleap 15.0 <dbauthuser_not_needed>` the last usages of the MySQL user ``dbauthuser`` were removed.
+If you still have this user in your MySQL database you should remove it.
+
+.. sourcecode:: sql
+
+    DROP USER IF EXISTS dbauthuser;
+
 
 Tuleap 16.0
 ===========


### PR DESCRIPTION
Part of request #40123 Do not export old config key sys_dbauth_passwd when collecting system data