### PR TITLE
fix: Production container should be built on a single-use agent

### DIFF
--- a/Jenkinsfile-build-docs.tuleap.org
+++ b/Jenkinsfile-build-docs.tuleap.org
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-        label 'docker'
+        label 'agent-one-time-use'
     }
 
     stages {


### PR DESCRIPTION
We want to be sure that other builds cannot influence the build of the production container.