### PR TITLE
fix: Update link to bz2tuleap container image

### DIFF
--- a/languages/en/administration-guide/projects-management/export-import/import-from-other-tools.rst
+++ b/languages/en/administration-guide/projects-management/export-import/import-from-other-tools.rst
@@ -23,7 +23,7 @@ You can integrate GitLab in Tuleap and improve your experience. Learn how to cre
 Bugzilla
 ''''''''
 
-Leveraging Tuleap XML import format, `bz2tuleap <https://hub.docker.com/r/enalean/bz2tuleap/>`_ is a tool that convert
+Leveraging Tuleap XML import format, `bz2tuleap <https://github.com/Enalean/bz2tuleap/pkgs/container/bz2tuleap>`_ is a tool that convert
 any Bugzilla XML query into an archive ready to be :doc:`imported <import-format>` into a Tuleap instance.
 
 Not only it will recreate the bugs and their comments with proper usernames and dates


### PR DESCRIPTION
Part of request #41477 Stop publishing enalean/bz2tuleap image on Docker Hub