### PR TITLE
docs: Remove outdated info from LDAP docs

### DIFF
--- a/languages/en/administration-guide/system-administration/services.rst
+++ b/languages/en/administration-guide/system-administration/services.rst
@@ -1,8 +1,9 @@
+********
 Services
-========
+********
 
 Network Ports
--------------
+=============
 
 * Web UI: 80 (HTTP) and 443 (HTTPS)
 * FTP: port 21
@@ -11,13 +12,13 @@ Network Ports
 
 
 Mysql
------
+=====
 
 Tuleap uses the MySQL database engine to store all of the project data.
 MySQL is fast, lightweight and very robust.
 
 Database Creation
-`````````````````
+-----------------
 
 The Tuleap database is created once when the Tuleap software is first
 installed. The scripts used to create and populate the database are
@@ -27,7 +28,7 @@ created or it will destroy all of your existing data !!
 
 
 Database Access Permissions
-```````````````````````````
+---------------------------
 
 MySQL has its own access permission management system that is completely
 independent from the access permission management system of the
@@ -53,7 +54,7 @@ are as follows:
    export. No password is needed for this user.
 
 Command Line
-````````````
+------------
 
 From any Unix account, type:
 
@@ -74,7 +75,7 @@ running it on the production server. Except for SELECT statements which
 are harmless anyway.
 
 Apache
-------
+======
 
 The Apache master configuration file is in /etc/httpd/conf/httpd.conf.
 The master file also includes specific configuration files located at
@@ -82,7 +83,7 @@ The master file also includes specific configuration files located at
 
 
 SSH
----
+===
 
 The Secure Shell service is available on Tuleap. All registered user
 with an active account can use it to login into Tuleap in a secure way.
@@ -94,7 +95,7 @@ and instruct your Windows users to install an SSH client instead.
 ..  _services_postfix:
 
 Postfix
--------
+=======
 
 By default Tuleap uses postfix as its mail transport agent of choice
 to handle incoming and outgoing mail messages. The critical files for
@@ -105,34 +106,31 @@ the sendmail configuration are:
 * ``/etc/aliases.codendi``: This file is generated automatically by the Tuleap daemon scripts and must never be edited by hand. The beginning of the file contains some predefined aliases (admin, contact, noreply,...) that must not be modified.
 
 LDAP
-----
+====
 
 **Set Up**
 
-You first need to install the ldap plugin in the Plugin Administration section.
+You first need to install the LDAP plugin in the Plugin Administration section.
 You will be asked to choose the default configuration template: either OpenLDAP or Active Directory.
 
 In ``/etc/tuleap/conf/local.inc`` you need to then set ``$sys_auth_type = 'ldap';``
 
 
-Once the plugin is installed, you will need to customise the properties in order to
-adapt it to your ldap server. Although you can tweak the settings from the plugin administration view,
-greater details and hidden options are available if you update
-``/etc/tuleap/plugins/ldap/etc/ldap.inc`` directly.
+Once the plugin is installed, you will need to customize the properties in order to
+adapt it to your LDAP server. To do so, update ``/etc/tuleap/plugins/ldap/etc/ldap.inc`` directly.
 
 **Daily Synchronisation**
 
-You can enable the Daily Synchronisation by setting the property ``sys_ldap_daily_sync`` to ``1`` in the plugin administration section of the interface.
-If activated, once per day, Tuleap will go through all the platform's ldap users and
+You can enable the Daily Synchronisation by setting the property ``sys_ldap_daily_sync`` to ``1`` in the ``/etc/tuleap/plugins/ldap/etc/ldap.inc`` file.
+If active, once per day, Tuleap will go through all the platform's LDAP users and
 
 * check they still exist in the LDAP directory. If not found, their accounts become suspended.
 * (OpenLDAP servers only) update the login name if it has changed.
 
-Note that you can also set the ``sys_ldap_daily_sync_retention_period`` (retention period) for suspended users, i.e. the number of days after which a suspended ldap user's status will switch to deleted.
+Note that you can also set the ``sys_ldap_daily_sync_retention_period`` (retention period) for suspended users, i.e. the number of days after which a suspended LDAP user's status will switch to deleted.
 Also, if you want to ensure that all your users do not become suspended due to a temporary server offline issue, you can set a threshold, ``sys_ldap_threshold_users_suspension``, i.e. the maximum percentage of users that can be suspended in one go.
 
 .. NOTE::
-  Active Directory limitations
-    * The ``GUID`` property as an identifier is not yet supported; you should use ``sAMAccountName``
-    * Consequently, if you rename a user, Tuleap is unable to know that the user has be renamed and considers that the user has been deleted and a new one created
-    * The currently experimental ``ldap write`` feature only works with an OpenLDAP type of server and the write server must also be the read server.
+  Active Directory limitations:
+    * The ``GUID`` property as an identifier is not supported; you should use ``sAMAccountName``
+    * Consequently, if you rename a user, Tuleap is unable to know that the user has been renamed and assumes that the user has been deleted and a new one created.


### PR DESCRIPTION
Why?
The LDAP write feature for Tuleap has been removed in June of 2023. We should remove mention of it in the user docs.
The ability to write plugin configuration in the siteadmin web UI has also been removed (I don't know when, sometime ago), we should point the user to the config file (although work is ongoing to replace it).

I changed the headings styles to match Sphinx docs convention [1]. I find that it avoids breaking my editor's syntax highlighting, like backticks do.

I also switched from "ldap" to "LDAP" because it's the more usual spelling (it is after all an acronym).

[0] https://tuleap.net/plugins/git/tuleap/tuleap/stable?a=blob&hb=5803f5b0eddfc4fd1eb4662dac7448db225366cc&f=docs%2Fdecisions%2F0024-remove-ldap-write.md
[1] https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections