### PR TITLE
chore: Disable Renovate lockfile maintainance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,5 @@
         ":preserveSemverRanges"
     ],
     "automerge": false,
-    "lockFileMaintenance": { "enabled": true },
     "timezone": "Europe/Paris"
 }


### PR DESCRIPTION
Updating all the transitives deps at once is probably not a good thing in our context as it could be harder to determine the source of an issue.