### PR TITLE
doc: Add uids/gids for docker backup/restore

### DIFF
--- a/languages/en/administration-guide/system-administration/backup.rst
+++ b/languages/en/administration-guide/system-administration/backup.rst
@@ -3,20 +3,19 @@
 Backup/Restore
 ==============
 
-
-Backup Tuleap
--------------
-
 This documentation is here to help you set up your backup. Be careful with this, it's just a guide and you will probably want to backup more things.
 
-If you installed Tuleap on a virtual environment and you are able to use snapshots, the simplest backup solution is to suspend tuleap services and then make a snapshot. Otherwise here are some tips to backup your Tuleap infrastructure:
+If you installed Tuleap on a virtual environment and you are able to use snapshots, the simplest backup solution is to suspend tuleap services and then make a snapshot.
+
+Otherwise here are some tips to backup and restore your Tuleap infrastructure.
+
+Backup for RPM Deployment on RHEL/Alma/Rocky
+--------------------------------------------
 
 Suspend services
 ````````````````
 
 Depending on services you use, you will want to stop them before the backup (It should guarantee you a consistent backup):
-
-On CentOS/RHEL 7:
 
 .. code-block:: bash
 
@@ -24,13 +23,6 @@ On CentOS/RHEL 7:
     $ systemctl stop httpd
     $ systemctl stop tuleap
     $ su - gitolite -c "gitolite writable @all off 'Backup in progress'"
-
-On Docker/Compose:
-
-.. code-block:: bash
-
-    $ cd /path_to_tuleap_compose
-    $ docker compose stop tuleap
 
 Don't forget to restart services once the backup is done.
 
@@ -43,21 +35,11 @@ Tuleap main database is ``tuleap``, but additionnal databases can be used for pl
 
     $ mysql -u codendiadm -p -e "show databases;"
 
-Use mysqldump to backup all databases. You can also write a script to backup each database independently:
+You can write a script to backup each database independently or use ``mysqldump`` to backup all databases:
 
 .. code-block:: bash
 
     $ mysqldump -u codendiadm -p --all-databases > mybackup.sql
-
-For docker you can use something like this:
-
-.. code-block:: bash
-
-    # Backup
-    docker exec SQL_CONTAINER /usr/bin/mysqldump -u codendiadm -p --all-databases > sqldump_all_tuleap.sql
-
-    # Restore (use root user for an empty server)
-    cat sqldump_all_tuleap.sql | docker exec -i SQL_CONTAINER /usr/bin/mysql -u root -p
 
 
 .. _tuleap_data_paths:
@@ -73,7 +55,47 @@ You need to save the following directories:
   - /var/lib/gitolite
   - /var/lib/tuleap
 
-Some directories might not exists depending on your configurations (plugins installed or not).
+Some directories might not exist depending on your configuration (plugins installed or not).
+
+
+Backup for Docker/Compose Deployment
+------------------------------------
+
+Suspend services
+````````````````
+
+Depending on the services you use, you will want to stop them before the process, it should guarantee you a consistent backup:
+
+.. code-block:: bash
+
+    $ cd /path_to/tuleap_compose
+    $ docker compose stop tuleap
+
+Don't forget to restart services once the backup is done.
+
+Database backup
+```````````````
+
+Tuleap main database is ``tuleap``, but additionnal databases can be used for plugins. To show them, use:
+
+.. code-block:: bash
+
+    $ docker exec SQL_CONTAINER /usr/bin/mysql -u codendiadm -p -e "show databases;"
+
+You can write a script to backup each database independently or use ``mysqldump`` to backup all databases:
+
+.. code-block:: bash
+
+    # Backup
+    docker exec SQL_CONTAINER /usr/bin/mysqldump -u codendiadm -p --all-databases > sqldump_all_tuleap.sql
+
+    # Restore (use root user for an empty server)
+    cat sqldump_all_tuleap.sql | docker exec -i SQL_CONTAINER /usr/bin/mysql -u root -p
+
+Tuleap docker data paths
+````````````````````````
+
+For a docker deployment, all data is stored in ``/data`` directory mapped from the container: backup all its content from the docker host.
 
 
 Restore Tuleap
@@ -83,20 +105,20 @@ As only data were backed up, you first need a Tuleap server to restore them. It 
 
   - suspend all services
   - restore databases (from a sqldump is the safest method to ensure compatibility between instances)
-  - restore directories (you must remap uids/gids if restoring from another instance, see below)
+  - restore directories (you must remap uids/gids if restoring from a RPM instance: see below)
   - run the site-deploy tool ``tuleap-cfg site-deploy``
   - restart services
 
 
-Backup/Restoration/Installation tips
-------------------------------------
+Restoration from RPM Deployment on RHEL/Alma/Rocky
+--------------------------------------------------
 
 uids/gids
 `````````
 
-If you plan to restore a backup from an instance to a new one, its likely that linux user and group ids have changed in between.
+If you plan to **restore a backup from an RPM instance** to a new one (RPM or Docker), its likely that linux user and group ``ids have changed`` in between.
 
-First you need to identify the old ids from your backup archive, looking for each of those files (that should be owned by) :
+First you need to **identify the old ids** from your backup archive or your old instance, looking for each of those files (that should be owned by) :
 
   - /etc/tuleap/conf/encryption_secret.key (codendiadm)
   - /var/lib/gitolite/.gitolite/conf/gitolite.conf (gitolite)
@@ -112,18 +134,26 @@ Example use of ``ls -ldn`` to display those ids
     -rw-rw----  1 976 976  867 Dec 21  2020 /var/lib/gitolite/.gitolite/conf/gitolite.conf
     drwxr-xr-x 22 979 978 4096 Oct 22 08:59 /var/lib/tuleap/ftp/pub
 
-Then construct the map from the 3rd (uid) and 4th (gid) columns and the associated owner name
+Then **construct the maps** from the 3rd (uid) and 4th (gid) columns and the associated owner name
   - usermap: ``980:codendiadm,976:gitolite,979:ftpadmin``
   - groupmap: ``980:codendiadm,976:gitolite,978:ftpadmin``
 
 As you can see, for ftpadmin uids and gids are not the same in this example.
 
-If you plan to migrate to ``docker``, you must use the following numerical ids as the users won't be created on the docker host:
+Migrate/Restore to Docker
+-------------------------
+
+If you plan to **migrate RPM to docker**, you must use the following numerical ids as the users won't be created on the docker host:
   - codendiadm: 900
   - gitolite: 902
   - ftpadmin: 904
 
 So the maps will be ``--usermap=980:900,976:902,979:904`` and ``--groupmap=980:900,976:902,978:904`` for a docker target in this exemple.
+
+If you are only **restoring a docker** instance **onto a docker** instance, those ids should already be set and a **remap is not necessary**.
+
+Remap uids with rsync
+---------------------
 
 Finally you can use a tool like ``rsync`` to help you remap your data while restoring/resyncing:
 
@@ -135,7 +165,7 @@ Finally you can use a tool like ``rsync`` to help you remap your data while rest
 
 
 Moving Tuleap folders to an external disk
-`````````````````````````````````````````
+-----------------------------------------
 
 For the mentioned :ref:`tuleap data paths <tuleap_data_paths>`, you could move them on a **separate data disk** for easier backup.
 

--- a/languages/en/administration-guide/system-administration/backup.rst
+++ b/languages/en/administration-guide/system-administration/backup.rst
@@ -118,6 +118,13 @@ Then construct the map from the 3rd (uid) and 4th (gid) columns and the associat
 
 As you can see, for ftpadmin uids and gids are not the same in this example.
 
+If you plan to migrate to ``docker``, you must use the following numerical ids as the users won't be created on the docker host:
+  - codendiadm: 900
+  - gitolite: 902
+  - ftpadmin: 904
+
+So the maps will be ``--usermap=980:900,976:902,979:904`` and ``--groupmap=980:900,976:902,978:904`` for a docker target in this exemple.
+
 Finally you can use a tool like ``rsync`` to help you remap your data while restoring/resyncing:
 
 .. code-block::


### PR DESCRIPTION
Users wanting to migrate to docker need a custom remap.
Adding uids/gids from [original TEE DockerFile](https://tuleap.net/plugins/git/tuleap/tuleap/stable?a=blob&hb=master&f=plugins%2Ftee_container%2Fdocker%2FDockerfile) 