### PR TITLE
fix: Search "extracts" are shown when the Tuleap is used

### DIFF
--- a/languages/en/_themes/tuleap_org/layout.html
+++ b/languages/en/_themes/tuleap_org/layout.html
@@ -1,6 +1,4 @@
 {# TEMPLATE VAR SETTINGS #}
-{%- set url_root = pathto('', 1) %}
-{%- if url_root == '#' %}{% set url_root = '' %}{% endif %}
 {%- if not embedded and docstitle %}
   {%- set titlesuffix = " &mdash; "|safe + docstitle|e %}
 {%- else %}
@@ -8,7 +6,7 @@
 {%- endif %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-content_root="{{ content_root }}">
 <head>
   <meta charset="utf-8">
   {{ metatags }}

--- a/languages/en/_themes/tuleap_org/static/documentation_options.js_t
+++ b/languages/en/_themes/tuleap_org/static/documentation_options.js_t
@@ -1,5 +1,4 @@
 var DOCUMENTATION_OPTIONS = {
-    URL_ROOT: '{{ url_root }}',
     VERSION: '{{ release|e }}',
     LANGUAGE: '{{ language }}',
     COLLAPSE_INDEX: false,


### PR DESCRIPTION
This fixes the search on the Tuleap theme, the extract of the content of the search results is not visible since the upgrade to Sphinx 7.2.