### PR TITLE
chore: Remove mentions of the SOAP API in the admin and user guides

### DIFF
--- a/languages/en/administration-guide/users-management/security/user-authentication/openidconnect.rst
+++ b/languages/en/administration-guide/users-management/security/user-authentication/openidconnect.rst
@@ -17,8 +17,6 @@ The OpenID Connect client plugin allows users to authenticate with an OpenID Con
     * WebDAV access (they should use :ref:`Access Keys <access-keys>`.)
     * Subversion access (they should use :ref:`Access Keys <access-keys>`.)
 
-    Access to **SOAP API is no longer possible** for users that switch to OpenID Connect.
-
 Generic Provider
 ****************
 

--- a/languages/en/user-guide/trackers/administration/configuration/field-usage-management.rst
+++ b/languages/en/user-guide/trackers/administration/configuration/field-usage-management.rst
@@ -187,9 +187,8 @@ The edition mode allows for fields configuration not available at the
 creation :
 
 -  **Change the field name**: the field name is different from the field
-   label. Field name is an internal name for the field. It is used in
-   SOAP API for instance. It must not contain any special characters.
-   Only lower case letters and "\_" are authorized.
+   label. Field name is an internal name for the field. It must not contain
+   any special characters. Only lower case letters and "\_" are authorized.
 
 -  **Add a decorator**: List values can be embellished with a decorator. A
    decorator is a colored square. There are two available color palettes: one


### PR DESCRIPTION
The SOAP API was removed in 2022.