### PR TITLE
fix: replace broken certbot instruction link

### DIFF
--- a/languages/en/installation-guide/step-by-step/tls-configuration.rst
+++ b/languages/en/installation-guide/step-by-step/tls-configuration.rst
@@ -5,7 +5,7 @@ Tuleap expects all connections to the web interface to be done over HTTPS. By de
 Using a self-signed certificate is not suitable for production environment, you will want to get a certificate recognized
 by a known certificate authority (CA).
 
-We recommend using an `ACME <https://www.rfc-editor.org/rfc/rfc8555.html>`_ client such as `Certbot <https://certbot.eff.org/instructions?ws=nginx&os=centosrhel7>`_
+We recommend using an `ACME <https://www.rfc-editor.org/rfc/rfc8555.html>`_ client such as `certbot <https://docs.rockylinux.org/10/guides/security/generating_ssl_keys_lets_encrypt/#using-certbot-with-nginx>`_
 to get a certificate signed from a certificate authority like `Let's Encrypt <https://letsencrypt.org/>`_ and to manage the deployment and renewal of the certificate.
 
 If you have custom needs, you should edit the nginx configuration file ``/etc/nginx/conf.d/tuleap.conf`` to


### PR DESCRIPTION
We now link to the Rocky Linux instructions which is likely better than generic ones.