### PR TITLE
chore: Use sha256 hash of nginx docker image

### DIFF
--- a/online-docs/Dockerfile
+++ b/online-docs/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /home/builder/tuleap-documentation
 
 RUN nix-shell --run 'npm ci && npm run build && make SPHINXOPTS="-D html_theme=tuleap_online_doc" html'
 
-FROM nginx:1.31.3-alpine
+FROM nginx:1.31.3-alpine@sha256:2776cd5b70d8983e27e9f5c90abee3d24c690014ae8ecbb529572d954a459096
 
 COPY online-docs/nginx.conf /etc/nginx/nginx.conf
 COPY --from=builder /home/builder/tuleap-documentation/_build/html/en/ /usr/share/nginx/html


### PR DESCRIPTION
Why?
Hashes are more precise than docker tags.